### PR TITLE
Remove hard-coded hostnames

### DIFF
--- a/files/ansible-hosts-multimaster.j2
+++ b/files/ansible-hosts-multimaster.j2
@@ -109,7 +109,7 @@ openshift_metrics_cassandra_pvc_size=50Gi
 {{ hostname }}.openstacklocal
 {% endfor %}
 {% for ip, hostname in env_details.worker_details.items() %}
-{% if hostname | match('.*-[012].*') %}
+{% if loop.index <= 3 %}
 {{ hostname }}.openstacklocal openshift_node_labels="{'router':'true','purpose':'tenant'}"
 {% else %}
 {{ hostname }}.openstacklocal openshift_node_labels="{'purpose':'tenant'}"

--- a/tools/create-user.sh
+++ b/tools/create-user.sh
@@ -10,8 +10,8 @@ if [[ -z $username ]] || [[ -z $password ]]; then
   exit 1
 else
   if [[ $debug != 0 ]]; then
-    ansible-playbook -e USERNAME=$username -e PASSWORD=$password playbooks/htpassword.yaml -vv
+    ansible-playbook --private-key ../../id_rsa_jenkins -i ../openshift-ansible-hosts -e USERNAME=$username -e PASSWORD=$password playbooks/htpassword.yaml -vv
   else
-    ansible-playbook -e USERNAME=$username -e PASSWORD=$password playbooks/htpassword.yaml
+    ansible-playbook --private-key ../../id_rsa_jenkins -i ../openshift-ansible-hosts -e USERNAME=$username -e PASSWORD=$password playbooks/htpassword.yaml
   fi
 fi

--- a/tools/playbooks/htpassword.yaml
+++ b/tools/playbooks/htpassword.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: master-0.openstacklocal
+- hosts: masters[0]
   tasks:
     - fetch:
         src: /etc/origin/master/htpasswd
@@ -10,17 +10,17 @@
     password: "{{ PASSWORD }}"
   tasks:
     - htpasswd:
-        path: tmp/master-0.openstacklocal/etc/origin/master/htpasswd
+        path: tmp/{{ groups.masters[0] }}/etc/origin/master/htpasswd
         name: "{{ username }}"
         password: "{{ password }}"
         crypt_scheme: apr_md5_crypt
 - hosts: masters
   tasks:
     - copy:
-        src: tmp/master-0.openstacklocal/etc/origin/master/htpasswd
+        src: tmp/{{ groups.masters[0] }}/etc/origin/master/htpasswd
         dest: /etc/origin/master/htpasswd
 - hosts: localhost
   tasks:
     - file:
-        path: tmp/master-0.openstacklocal/
+        path: tmp/{{ groups.masters[0] }}/
         state: absent


### PR DESCRIPTION
It's bad practice to hardcode things. It should be dynamic incase we ever need to change hostnames in the future.