### PR TITLE
Add commands to enable haproxy and keepalived

### DIFF
--- a/setup_haproxy.yaml
+++ b/setup_haproxy.yaml
@@ -25,6 +25,8 @@
           $UDPServerAddress 127.0.0.1
           # Save haproxy logs to haproxy.log
           local2.* /var/log/haproxy.log
+    - name: Enable haproxy
+      command: systemctl enable haproxy
     - name: Restart haproxy
       command: systemctl restart haproxy
     - name: Restart rsyslog

--- a/setup_keepalived.yaml
+++ b/setup_keepalived.yaml
@@ -20,6 +20,8 @@
         dest: /etc/keepalived/keepalived.conf
         force: yes
         backup: yes
+    - name: Enable keepalived
+      command: systemctl enable keepalived
     - name: Start keepalived
       command: systemctl start keepalived
     - name: Setup kernal bind parameters


### PR DESCRIPTION
Tested to confirm that haproxy and keepalived is left in enabled state meaning that services will start on reboot.