### PR TITLE
replace deprecated 'include' statements'

### DIFF
--- a/openshift.yml
+++ b/openshift.yml
@@ -1,4 +1,4 @@
-- include: /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+- import_playbook: /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 
 - hosts: masters[0]
   roles:

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,3 +1,3 @@
 - include_tasks: dns_common.yml
 - include_tasks: dns_master.yml
-- include_tasks: dns_save.yml
+- include_tasks: dns_slave.yml

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: dns_common.yml
-- include: dns_master.yml
-- include: dns_slave.yml
+- include_tasks: dns_common.yml
+- include_tasks: dns_master.yml
+- include_tasks: dns_save.yml

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
-- include: loadbalancers.yml
-- include: dns.yml
-- include: all_servers.yml
-- include: openshift.yml
-- include: monitoring.yml
+- import_playbook: loadbalancers.yml
+- import_playbook: dns.yml
+- import_playbook: all_servers.yml
+- import_playbook: openshift.yml
+- import_playbook: monitoring.yml


### PR DESCRIPTION
I replaced all the deprecated "include" statements. 

There are still some in the 3rd party openshift-ansible playbook code that I can't change (but they're dealt with here: https://github.com/openshift/openshift-ansible/issues/5586)