### PR TITLE
Hotfix/add metrics tier config

### DIFF
--- a/deploy-openshift.sh
+++ b/deploy-openshift.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# Temporary: Patch the openshift-ansible install_cassandra.yaml for version 3.6.173.0.48-1
+yum list openshift-ansible 2>&1 | grep 3.6.173.0.48-1 >/dev/null
+if [ $? -eq 0 ]; then
+	curl https://raw.githubusercontent.com/openshift/openshift-ansible/80d141b5d60da9afbd3c02350933c090d1839c46/roles/openshift_metrics/tasks/install_cassandra.yaml > /tmp/install_cassandra.yaml
+	sudo cp /tmp/install_cassandra.yaml /usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/
+
+	echo "/usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/install_cassandra.yaml has been tweaked"
+	ls -l /usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/install_cassandra.yaml
+fi
+
+# End of temporary hack
+
 # build the openshift-ansible-hosts file for use in the next play.
 ansible-playbook -i localhost, -c local bastion.yml
 

--- a/deploy-openshift.sh
+++ b/deploy-openshift.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Temporary: Patch the openshift-ansible install_cassandra.yaml for version 3.6.173.0.48-1
+# RH support case 01975215 is open for this. Version in the grep may need to be updated
+# if another broken version is pushed to the repo
 yum list openshift-ansible 2>&1 | grep 3.6.173.0.48-1 >/dev/null
 if [ $? -eq 0 ]; then
 	curl https://raw.githubusercontent.com/openshift/openshift-ansible/80d141b5d60da9afbd3c02350933c090d1839c46/roles/openshift_metrics/tasks/install_cassandra.yaml > /tmp/install_cassandra.yaml

--- a/deploy-openshift.sh
+++ b/deploy-openshift.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Temporary: Patch the openshift-ansible install_cassandra.yaml for version 3.6.173.0.48-1
+# and also 3.6.173.0.75-1
 # RH support case 01975215 is open for this. Version in the grep may need to be updated
 # if another broken version is pushed to the repo
-yum list openshift-ansible 2>&1 | grep 3.6.173.0.48-1 >/dev/null
+yum list openshift-ansible 2>&1 | grep -e 3.6.173.0.48-1 -e 3.6.173.0.75-1 >/dev/null
 if [ $? -eq 0 ]; then
 	curl https://raw.githubusercontent.com/openshift/openshift-ansible/80d141b5d60da9afbd3c02350933c090d1839c46/roles/openshift_metrics/tasks/install_cassandra.yaml > /tmp/install_cassandra.yaml
 	sudo cp /tmp/install_cassandra.yaml /usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -28,6 +28,10 @@ openshift_master_cluster_method=native
 openshift_master_cluster_hostname=console.{{ localDomainSuffix }}
 openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 
+# Temporary fix for issue - NoVolumeZoneConflict predicate stops volume provisioning - needs Red Hat to diagnose because
+# specifying the predicates explicitly would prevent any future change of defaults in future versions
+openshift_master_scheduler_predicates=[{ "name": "MaxEBSVolumeCount" }, { "name": "MaxGCEPDVolumeCount" }, { "name": "MatchInterPodAffinity" }, { "name": "NoDiskConflict" },  { "name": "GeneralPredicates" }, { "name": "PodToleratesNodeTaints" }, { "name": "CheckNodeMemoryPressure" }, { "name": "CheckNodeDiskPressure"  }, {  "argument": {  "serviceAffinity": { "labels": [ "region" ] } }, "name": "Region" }]
+
 openshift_set_hostname=true
 
 # Makes the openshift_ip setting in the host groups are below take effect.

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -34,6 +34,7 @@ openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 openshift_master_scheduler_predicates=[{ "name": "MaxEBSVolumeCount" }, { "name": "MaxGCEPDVolumeCount" }, { "name": "MatchInterPodAffinity" }, { "name": "NoDiskConflict" },  { "name": "GeneralPredicates" }, { "name": "PodToleratesNodeTaints" }, { "name": "CheckNodeMemoryPressure" }, { "name": "CheckNodeDiskPressure"  }, {  "argument": {  "serviceAffinity": { "labels": [ "region" ] } }, "name": "Region" }]
 
 openshift_set_hostname=true
+openshift_release=v{{ openshiftVersion }}
 
 # Makes the openshift_ip setting in the host groups are below take effect.
 # This sets the nodeIP setting in node-config on each host to the correct IP

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -88,6 +88,14 @@ openshift_hosted_metrics_deploy=true
 openshift_hosted_metrics_public_url=https://hawkular-metrics.{{ domainSuffix }}/hawkular/metrics
 openshift_hosted_metrics_storage_kind=dynamic
 openshift_metrics_cassandra_pvc_size=50Gi
+## cassandra is misspelt in the openshift-ansible 3.6.173.0.48-1 code so line below needs "cassanda"
+openshift_metrics_cassanda_pvc_storage_class_name=tier-2
+## and again with the correct spelling, incase the typo is fixed in the future
+openshift_metrics_cassandra_pvc_storage_class_name=tier-2
+## Also, for 3.6.173.0.48-1, ^ this ^ config is completely ignored unless you backport a fix by adding Line 57 from
+## https://github.com/openshift/openshift-ansible/blob/80d141b5d60da9afbd3c02350933c090d1839c46/roles/openshift_metrics/tasks/install_cassandra.yaml#L57
+# into /usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/install_cassandra.yaml before the deployment runs.
+# RH support case 01975215 is open for this...
 
 # Create an OSEv3 group that contains the masters and nodes groups
 # host group for masters

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -95,6 +95,7 @@ openshift_metrics_cassandra_pvc_storage_class_name=tier-2
 ## Also, for 3.6.173.0.48-1, ^ this ^ config is completely ignored unless you backport a fix by adding Line 57 from
 ## https://github.com/openshift/openshift-ansible/blob/80d141b5d60da9afbd3c02350933c090d1839c46/roles/openshift_metrics/tasks/install_cassandra.yaml#L57
 # into /usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/install_cassandra.yaml before the deployment runs.
+# This has be added as a messy hack in deploy-openshift.sh which will only run if version remains at 3.6.173.0.48-1
 # RH support case 01975215 is open for this...
 
 # Create an OSEv3 group that contains the masters and nodes groups

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -30,6 +30,7 @@ openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 
 # Temporary fix for issue - NoVolumeZoneConflict predicate stops volume provisioning - needs Red Hat to diagnose because
 # specifying the predicates explicitly would prevent any future change of defaults in future versions
+# Red Hat support case 01975965 is open about this.
 openshift_master_scheduler_predicates=[{ "name": "MaxEBSVolumeCount" }, { "name": "MaxGCEPDVolumeCount" }, { "name": "MatchInterPodAffinity" }, { "name": "NoDiskConflict" },  { "name": "GeneralPredicates" }, { "name": "PodToleratesNodeTaints" }, { "name": "CheckNodeMemoryPressure" }, { "name": "CheckNodeDiskPressure"  }, {  "argument": {  "serviceAffinity": { "labels": [ "region" ] } }, "name": "Region" }]
 
 openshift_set_hostname=true

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -52,9 +52,6 @@ openshift_hosted_registry_selector='purpose=tenant'
 openshift_hosted_registry_replicas=1
 #openshift_hosted_registry_storage_kind=openstack
 #openshift_hosted_registry_storage_access_modes=['ReadWriteOnce']
-#openshift_hosted_registry_storage_openstack_filesystem=ext4
-#openshift_hosted_registry_storage_openstack_volumeID={{ registryVolume }}
-#openshift_hosted_registry_storage_volume_size={{ registryVolumeSize }}
 
 # Any S3 service (Minio, ExoScale, ...): Basically the same as above
 # but with regionendpoint configured
@@ -93,11 +90,11 @@ openshift_hosted_metrics_deploy=true
 openshift_hosted_metrics_public_url=https://hawkular-metrics.{{ domainSuffix }}/hawkular/metrics
 openshift_hosted_metrics_storage_kind=dynamic
 openshift_metrics_cassandra_pvc_size=50Gi
-## cassandra is misspelt in the openshift-ansible 3.6.173.0.48-1 code so line below needs "cassanda"
+## cassandra is misspelt in the openshift-ansible 3.6.173 code so line below needs "cassanda"
 openshift_metrics_cassanda_pvc_storage_class_name=tier-2
 ## and again with the correct spelling, incase the typo is fixed in the future
 openshift_metrics_cassandra_pvc_storage_class_name=tier-2
-## Also, for 3.6.173.0.48-1, ^ this ^ config is completely ignored unless you backport a fix by adding Line 57 from
+## Also, for 3.6.173.0.48-1 and 3.6.173.0.75-1, ^ this ^ config is completely ignored unless you backport a fix by adding Line 57 from
 ## https://github.com/openshift/openshift-ansible/blob/80d141b5d60da9afbd3c02350933c090d1839c46/roles/openshift_metrics/tasks/install_cassandra.yaml#L57
 # into /usr/share/ansible/openshift-ansible/roles/openshift_metrics/tasks/install_cassandra.yaml before the deployment runs.
 # This has be added as a messy hack in deploy-openshift.sh which will only run if version remains at 3.6.173.0.48-1


### PR DESCRIPTION
Explicitly sets the tier for the metrics pvc. This is required for 3.6

Unfortunately this uncovered various bugs in OpenShift 3.6 and and openshift-ansible 3.6.173.0.48-1 so this includes some nasty hacks to work around these; at least some have been fixed in the upstream github repo and I am following up with Red Hat to see when fixes will be back-ported to 3.6 OCP


Testing - it installs 3.6 and will also install 3.5 once ansible is rolled back to ansible-2.4.0.0