### PR TITLE
Removed reference to registry volume vars

### DIFF
--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -51,8 +51,8 @@ openshift_hosted_registry_replicas=1
 #openshift_hosted_registry_storage_kind=openstack
 #openshift_hosted_registry_storage_access_modes=['ReadWriteOnce']
 #openshift_hosted_registry_storage_openstack_filesystem=ext4
-#openshift_hosted_registry_storage_openstack_volumeID={{ registryVolume }}
-#openshift_hosted_registry_storage_volume_size={{ registryVolumeSize }}
+#openshift_hosted_registry_storage_openstack_volumeID=
+#openshift_hosted_registry_storage_volume_size=
 
 # Any S3 service (Minio, ExoScale, ...): Basically the same as above
 # but with regionendpoint configured


### PR DESCRIPTION
Since the ansible-hosts-multimaster.j2 is preparsed, even commented out lines will trigger var-not-found errors now that registryVolume is removed from the heat deployment.