### PR TITLE
Feature/i41 create user

### DIFF
--- a/bastion-post-deploy.yml
+++ b/bastion-post-deploy.yml
@@ -15,8 +15,9 @@
 
   - name: update passwords
     shell: |
-      ansible-playbook --private-key ~/id_rsa_jenkins -i openshift-ansible-hosts -e USERNAME='admin' -e PASSWORD="{{ new_admin_password }}" tools/playbooks/htpassword.yaml
-      ansible-playbook --private-key ~/id_rsa_jenkins -i openshift-ansible-hosts -e USERNAME='demo' -e PASSWORD="{{ new_user_password }}" tools/playbooks/htpassword.yaml
+      cd tools
+      ./create-user.sh 'admin' "{{ new_admin_password }}"
+      ./create-user.sh 'demo' "{{ new_user_password }}"
 
   - name: create text file
     shell: |

--- a/tools/create-user.sh
+++ b/tools/create-user.sh
@@ -8,10 +8,15 @@ if [[ -z $username ]] || [[ -z $password ]]; then
   echo -e "help: This script will add users to htpasswd for OpenShift.\n\n"
   echo -e "usage: $0 <username> <password>\n"
   exit 1
-else
-  if [[ $debug != 0 ]]; then
-    ansible-playbook --private-key ~/id_rsa_jenkins -i ../openshift-ansible-hosts -e USERNAME=$username -e PASSWORD=$password playbooks/htpassword.yaml -vv
-  else
-    ansible-playbook --private-key ~/id_rsa_jenkins -i ../openshift-ansible-hosts -e USERNAME=$username -e PASSWORD=$password playbooks/htpassword.yaml
-  fi
 fi
+
+privkey=~/id_rsa_jenkins
+inventory=../openshift-ansible-hosts
+playbook=playbooks/htpassword.yaml
+extras=""
+
+if [[ $debug != 0 ]]; then
+    extras="-vv"
+fi
+
+ansible-playbook --private-key $privkey -i $inventory -e USERNAME=$username -e PASSWORD=$password $extras $playbook

--- a/tools/playbooks/htpassword.yaml
+++ b/tools/playbooks/htpassword.yaml
@@ -1,9 +1,13 @@
+# Modify the htpasswd file and replicate it
+# across all master nodes
+
 ---
 - hosts: masters[0]
   tasks:
     - fetch:
         src: /etc/origin/master/htpasswd
         dest: tmp/
+
 - hosts: localhost
   vars:
     username: "{{ USERNAME }}"
@@ -14,11 +18,13 @@
         name: "{{ username }}"
         password: "{{ password }}"
         crypt_scheme: apr_md5_crypt
+
 - hosts: masters
   tasks:
     - copy:
         src: tmp/{{ groups.masters[0] }}/etc/origin/master/htpasswd
         dest: /etc/origin/master/htpasswd
+
 - hosts: localhost
   tasks:
     - file:


### PR DESCRIPTION
Improvements to create user script, and where it's used in bastion-post-deploy.yml.

It is not possible to call a playbook from within a task. Simplified bastion-post-deploy to call "create-user.sh" instead