### PR TITLE
Bugfix/haproxy timeout

### DIFF
--- a/roles/haproxy/templates/haproxy.j2
+++ b/roles/haproxy/templates/haproxy.j2
@@ -107,6 +107,8 @@ backend atomic-openshift-router-ssl
   backend atomic-openshift-api
     balance source
     mode tcp
+    timeout check 2s
+    timeout connect 2s
     {% for ip, hostname in master_details.items() %}
       server     {{ hostname }} {{ ip }}:8443 check
     {% endfor %}

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -1,36 +1,34 @@
 #!/bin/bash
 
-# Ensuring admin username and admin password are passed to script in Jenkinsfile.
+# Ensure admin username and admin password are passed to script in Jenkinsfile.
 if  [[ -z $1 ]] || [[ -z $2 ]]
 then
-	echo "Admin username and password not provided. Ending script."
+	echo "Usage $0 <admin username> <admin password>"
 	exit 1
 fi
 
-# Moving to correct directory to run commands with relative paths
+# Move to correct directory to run commands with relative paths
 cd /usr/share/ansible/openshift-deployment-ansible/tests/haproxy 
 
-# Logging into openshift in order to run oc commands later in script.
-oc login -u $1 -p $2 --server="https://ocp.$(cat ../../group_vars/all.yml \
-| grep domainSuffix | awk '{print $2}'):8443" --insecure-skip-tls-verify
+# Logging into openshift in order to run oc commands later in script. 
+DOMAINSUFFIX=cat ../../group_vars/all.yml | grep domainSuffix | awk '{print $2}'
+
+oc login -u $1 -p $2 --server="https://ocp.$DOMAINSUFFIX:8443" --insecure-skip-tls-verify
 
 oc project default
 
 # Variables to store state of master nodes
-master0state=$(oc get node | grep master-0 | awk '{ print $2 }' | cut -d , -f 1)
-master1state=$(oc get node | grep master-1 | awk '{ print $2 }' | cut -d , -f 1)
-master2state=$(oc get node | grep master-2 | awk '{ print $2 }' | cut -d , -f 1)
+master0state=$(oc get node | grep master-.*0 | awk '{ print $2 }' | cut -d , -f 1)
+master1state=$(oc get node | grep master-.*1 | awk '{ print $2 }' | cut -d , -f 1)
+master2state=$(oc get node | grep master-.*2 | awk '{ print $2 }' | cut -d , -f 1)
 
-echo Script starting this will take around 2 minutes to complete.
-echo
-
-# Creates symbolic link to ansible config file in order to send log output to ~/ansible.log
+# Create symbolic link to ansible config file in order to send log output to ~/ansible.log
 if [[ ! -L ansible.cfg ]]
 then
 	ln -s ../../ansible.cfg ansible.cfg
 fi
 
-# Checks the master nodes are in state "Ready" and exits script if not. If they are it runs the ansible playbooks to poll the API and hard reboot the master nodes in turn.
+# Check the master nodes are in state "Ready" and exit the script if not. If they are it runs the ansible playbooks to poll the API and hard reboot the master nodes in turn.
 if [[ $master0state != Ready ]] || [[ $master1state != Ready ]] || [[ $master2state != Ready ]]
 then
 	echo "One of more master nodes is not in state "Ready" please correct this and run the script again." 
@@ -42,24 +40,24 @@ else
 	ansible-playbook node_rotate.yml & 
 fi
  
-# Loop to wait until the node_rotate playbook is finished and allow the poll playbook to be killed once it is.
+# Wait until the node_rotate playbook is finished and allow the poll playbook to be killed once it is.
 until [[ -z $(ps -ef | grep "/[u]sr/bin/ansible-playbook node_rotate.yml" | awk '{ print $2}') ]]
 do
 	sleep 1
 done
  
-# Writes output of poll playbook to haproxytest.log determines this from the playbook PID.
+# Write output of poll playbook to haproxytest.log determines this from the playbook PID.
 cat ~/ansible.log | grep $(ps -ef | grep "/[u]sr/bin/ansible-playbook poll.yml" | awk '{ print $2}' | head -1) > haproxytest.log
  
-#Kills poll playbook.
+# Kill poll playbook.
 ps -ef | grep "/[u]sr/bin/ansible-playbook poll.yml" | awk '{ print $2}' | xargs -x kill -9
  
-#Uses regex to filter haproxytest.log for the information needed and then write it back to the log.
+# Filter haproxytest.log for the information needed and then write it back to the log.
 perl -ne 'print if /item=\d/' haproxytest.log | awk '{ print $1 " " $2 " connection " $6}' > connect.log
  
 rm haproxytest.log
  
-#Prints out total downtime in seconds.
+# Print out total downtime in seconds.
 echo
 echo $(cat connect.log | grep failed | awk '{ print $2 }' | cut -d ":" -f 3 | sed s/,/./g | awk 'p{print $0-p}{p=$0}' | awk '{total = total + $1}END{print "There was a total of " total " seconds downtime"}') | tee -a connect.log
 echo

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Ensuring admin username and admin password are passed to script in Jenkinsfile.
+if  [[ -z $1 ]] || [[ -z $2 ]]
+then
+	echo "Admin username and password not provided. Ending script."
+	exit 1
+fi
+
+# Logging into openshift in order to run oc commands later in script.
+oc login -u $1 -p $2 --server="https://ocp.$(cat ../../group_vars/all.yml \
+| grep domainSuffix | awk '{print $2}'):8443" --insecure-skip-tls-verify
+
+oc project default
+
+# Variables to store state of master nodes
+master0state=$(oc get node | grep master-0 | awk '{ print $2 }' | cut -d , -f 1)
+master1state=$(oc get node | grep master-1 | awk '{ print $2 }' | cut -d , -f 1)
+master2state=$(oc get node | grep master-2 | awk '{ print $2 }' | cut -d , -f 1)
+
+echo Script starting this will take around 2 minutes to complete.
+echo
+
+# Creates symbolic link to ansible config file in order to send log output to ~/ansible.log
+if [[ ! -L ansible.cfg ]]
+then
+	ln -s ../../ansible.cfg ansible.cfg
+fi
+
+# Checks the master nodes are in state "Ready" and exits script if not. If they are it runs the ansible playbooks to poll the API and hard reboot the master nodes in turn.
+if [[ $master0state != Ready ]] || [[ $master1state != Ready ]] || [[ $master2state != Ready ]]
+then
+	echo "One of more master nodes is not in state "Ready" please correct this and run the script again." 
+	echo
+	exit 1
+else
+	ansible-playbook poll.yml &
+	sleep 2
+	ansible-playbook node_rotate.yml & 
+fi
+ 
+# Loop to wait until the node_rotate playbook is finished and allow the poll playbook to be killed once it is.
+until [[ -z $(ps -ef | grep "/[u]sr/bin/ansible-playbook node_rotate.yml" | awk '{ print $2}') ]]
+do
+	sleep 1
+done
+ 
+# Writes output of poll playbook to haproxytest.log determines this from the playbook PID.
+cat ~/ansible.log | grep $(ps -ef | grep "/[u]sr/bin/ansible-playbook poll.yml" | awk '{ print $2}' | head -1) > haproxytest.log
+ 
+#Kills poll playbook.
+ps -ef | grep "/[u]sr/bin/ansible-playbook poll.yml" | awk '{ print $2}' | xargs -x kill -9
+ 
+#Uses regex to filter haproxytest.log for the information needed and then write it back to the log.
+perl -ne 'print if /item=\d/' haproxytest.log | awk '{ print $1 " " $2 " connection " $6}' > connect.log
+ 
+rm haproxytest.log
+ 
+#Prints out total downtime in seconds.
+echo
+echo $(cat connect.log | grep failed | awk '{ print $2 }' | cut -d ":" -f 3 | sed s/,/./g | awk 'p{print $0-p}{p=$0}' | awk '{total = total + $1}END{print "There was a total of " total " seconds downtime"}') | tee -a connect.log
+echo
+echo Results of script saved in connect.log
+echo
+echo "End of script." 
+

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -16,10 +16,9 @@ DOMAINSUFFIX=$(cat ../../group_vars/all.yml | grep domainSuffix | awk '{print $2
 oc login -u $1 -p $2 --server="https://ocp.$DOMAINSUFFIX:8443" --insecure-skip-tls-verify
 
 # Storing master node names (easiest way to do this and ensure future proof for node changes)
-masters="$(oc get nodes -o custom-columns=NAME:metadata.name --no-headers=true | grep master)"
-master0name=$("${masters}" | grep -- -0.)
-master1name=$("${masters}" | grep -- -1.)
-master2name=$("${masters}" | grep -- -2.)
+master0name=$(oc get nodes -o custom-columns=NAME:metadata.name --no-headers=true | grep master | grep -- -0.)
+master1name=$(oc get nodes -o custom-columns=NAME:metadata.name --no-headers=true | grep master | grep -- -1.)
+master2name=$(oc get nodes -o custom-columns=NAME:metadata.name --no-headers=true | grep master | grep -- -2.)
 
 # Variables to store state of master nodes
 master0state=$(oc get node | grep $master0name | awk '{ print $2 }' | cut -d , -f 1)

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -7,6 +7,9 @@ then
 	exit 1
 fi
 
+# Moving to correct directory to run commands with relative paths
+cd /usr/share/ansible/openshift-deployment-ansible/tests/haproxy 
+
 # Logging into openshift in order to run oc commands later in script.
 oc login -u $1 -p $2 --server="https://ocp.$(cat ../../group_vars/all.yml \
 | grep domainSuffix | awk '{print $2}'):8443" --insecure-skip-tls-verify

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -41,11 +41,11 @@ then
 else
 	ansible-playbook poll.yml &
 	sleep 2
-	ansible-playbook -i ../../openshift-anbsible-hosts node_rotate.yml & 
+	ansible-playbook -i ../../openshift-ansible-hosts node_rotate.yml & 
 fi
  
 # Wait until the node_rotate playbook is finished and allow the poll playbook to be killed once it is.
-until [[ -z $(ps -ef | grep "/[u]sr/bin/ansible-playbook -i ../../openshift-anbsible-hosts node_rotate.yml" | awk '{ print $2}') ]]
+until [[ -z $(ps -ef | grep "/[u]sr/bin/ansible-playbook -i ../../openshift-ansible-hosts node_rotate.yml" | awk '{ print $2}') ]]
 do
 	sleep 1
 done

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -41,7 +41,7 @@ then
 else
 	ansible-playbook poll.yml &
 	sleep 2
-	ansible-playbook node_rotate.yml & 
+	ansible-playbook node_rotate.yml -i ../../openshift-anbsible-hosts & 
 fi
  
 # Wait until the node_rotate playbook is finished and allow the poll playbook to be killed once it is.

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -15,12 +15,15 @@ DOMAINSUFFIX=$(cat ../../group_vars/all.yml | grep domainSuffix | awk '{print $2
 
 oc login -u $1 -p $2 --server="https://ocp.$DOMAINSUFFIX:8443" --insecure-skip-tls-verify
 
-oc project default
+# Storing master node names (easiest way to do this and ensure future proof for node changes)
+master0name=$(cat ../../openshift-ansible-hosts | fgrep -C3 [masters] | tail -3 | head -1)
+master1name=$(cat ../../openshift-ansible-hosts | fgrep -C3 [masters] | tail -2 | head -1)
+master2name=$(cat ../../openshift-ansible-hosts | fgrep -C3 [masters] | tail -1)
 
 # Variables to store state of master nodes
-master0state=$(oc get node | grep master-.*0 | awk '{ print $2 }' | cut -d , -f 1)
-master1state=$(oc get node | grep master-.*1 | awk '{ print $2 }' | cut -d , -f 1)
-master2state=$(oc get node | grep master-.*2 | awk '{ print $2 }' | cut -d , -f 1)
+master0state=$(oc get node | grep $master0name | awk '{ print $2 }' | cut -d , -f 1)
+master1state=$(oc get node | grep $master1name | awk '{ print $2 }' | cut -d , -f 1)
+master2state=$(oc get node | grep $master2name | awk '{ print $2 }' | cut -d , -f 1)
 
 # Create symbolic link to ansible config file in order to send log output to ~/ansible.log
 if [[ ! -L ansible.cfg ]]

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -11,7 +11,7 @@ fi
 cd /usr/share/ansible/openshift-deployment-ansible/tests/haproxy 
 
 # Logging into openshift in order to run oc commands later in script. 
-DOMAINSUFFIX=cat ../../group_vars/all.yml | grep domainSuffix | awk '{print $2}'
+DOMAINSUFFIX=$(cat ../../group_vars/all.yml | grep domainSuffix | awk '{print $2}')
 
 oc login -u $1 -p $2 --server="https://ocp.$DOMAINSUFFIX:8443" --insecure-skip-tls-verify
 

--- a/tests/haproxy/master-failover-test.sh
+++ b/tests/haproxy/master-failover-test.sh
@@ -41,11 +41,11 @@ then
 else
 	ansible-playbook poll.yml &
 	sleep 2
-	ansible-playbook node_rotate.yml -i ../../openshift-anbsible-hosts & 
+	ansible-playbook -i ../../openshift-anbsible-hosts node_rotate.yml & 
 fi
  
 # Wait until the node_rotate playbook is finished and allow the poll playbook to be killed once it is.
-until [[ -z $(ps -ef | grep "/[u]sr/bin/ansible-playbook node_rotate.yml" | awk '{ print $2}') ]]
+until [[ -z $(ps -ef | grep "/[u]sr/bin/ansible-playbook -i ../../openshift-anbsible-hosts node_rotate.yml" | awk '{ print $2}') ]]
 do
 	sleep 1
 done

--- a/tests/haproxy/node_rotate.yml
+++ b/tests/haproxy/node_rotate.yml
@@ -1,7 +1,7 @@
 # This file sets environment variables needed to run openstack commands on the bastion and then brings down the master nodes in turn, waiting until the last one comes up to bring down the next.
 - hosts: localhost
   environment:
-    OS_AUTH_URL: "{{ openshift_cloudprovider_openstack_auth_url }}"
+    OS_AUTH_URL: "{{ osAuthUrl }}"
     OS_TENANT_ID: "{{ osTenantId }}"
     OS_TENANT_NAME: "{{ osTenantName }}"
     OS_USERNAME: "{{ openstackOpenshiftUsername }}"

--- a/tests/haproxy/node_rotate.yml
+++ b/tests/haproxy/node_rotate.yml
@@ -13,39 +13,39 @@
   
   tasks:
   - name: reboot master-0
-    shell: nova reboot --hard "{{ master0 }}"
+    shell: nova reboot --hard {{ master0 }}
 
   - pause:
       seconds: 40
 
   - name: Get status of master-0
-    shell: oc get node | grep "{{ master0 }}"  | awk '{ print $2 }' | cut -d , -f 1
+    shell: oc get node | grep {{ master0 }}  | awk '{ print $2 }' | cut -d , -f 1
     register: master0status
     until: master0status.stdout == "Ready"
     delay: 5
     retries: 5
 
   - name: reboot master-1
-    shell: nova reboot --hard "{{ master1 }}" 
+    shell: nova reboot --hard {{ master1 }}
 
   - pause:
       seconds: 40
  
   - name: Get status of master-1
-    shell: oc get node | grep "{{ master1 }}" | awk '{ print $2 }' | cut -d , -f 1
+    shell: oc get node | grep {{ master1 }} | awk '{ print $2 }' | cut -d , -f 1
     register: master1status
     until: master1status.stdout == "Ready"
     delay: 5
     retries: 5
 
   - name: reboot master-2
-    shell: nova reboot --hard "{{ master2 }}"
+    shell: nova reboot --hard {{ master2 }}
 
   - pause:
       seconds: 40
 
   - name: Get status of master-2
-    shell: oc get node | grep "{{ master2 }}" | awk '{ print $2 }' | cut -d , -f 1
+    shell: oc get node | grep {{ master2 }} | awk '{ print $2 }' | cut -d , -f 1
     register: master2status
     until: master2status.stdout == "Ready"
     delay: 5

--- a/tests/haproxy/node_rotate.yml
+++ b/tests/haproxy/node_rotate.yml
@@ -13,39 +13,39 @@
   
   tasks:
   - name: reboot master-0
-    shell: nova reboot --hard {{ master0 }}
+    shell: nova reboot --hard "{{ master0 }}"
 
   - pause:
       seconds: 40
 
   - name: Get status of master-0
-    shell: oc get node | grep {{ master0 }}  | awk '{ print $2 }' | cut -d , -f 1
+    shell: oc get node | grep "{{ master0 }}"  | awk '{ print $2 }' | cut -d , -f 1
     register: master0status
     until: master0status.stdout == "Ready"
     delay: 5
     retries: 5
 
   - name: reboot master-1
-    shell: nova reboot --hard {{ master1 }}
+    shell: nova reboot --hard "{{ master1 }}"
 
   - pause:
       seconds: 40
  
   - name: Get status of master-1
-    shell: oc get node | grep {{ master1 }} | awk '{ print $2 }' | cut -d , -f 1
+    shell: oc get node | grep "{{ master1 }}" | awk '{ print $2 }' | cut -d , -f 1
     register: master1status
     until: master1status.stdout == "Ready"
     delay: 5
     retries: 5
 
   - name: reboot master-2
-    shell: nova reboot --hard {{ master2 }}
+    shell: nova reboot --hard "{{ master2 }}"
 
   - pause:
       seconds: 40
 
   - name: Get status of master-2
-    shell: oc get node | grep {{ master2 }} | awk '{ print $2 }' | cut -d , -f 1
+    shell: oc get node | grep "{{ master2 }}" | awk '{ print $2 }' | cut -d , -f 1
     register: master2status
     until: master2status.stdout == "Ready"
     delay: 5

--- a/tests/haproxy/node_rotate.yml
+++ b/tests/haproxy/node_rotate.yml
@@ -6,43 +6,47 @@
     OS_TENANT_NAME: "{{ osTenantName }}"
     OS_USERNAME: "{{ openstackOpenshiftUsername }}"
     OS_PASSWORD: "{{ openstackOpenshiftPassword }}"
+  vars:
+    master0: "{{ groups['masters'][0] }}"
+    master1: "{{ groups['masters'][1] }}"
+    master2: "{{ groups['masters'][2] }}"
   
   tasks:
   - name: reboot master-0
-    shell: nova reboot --hard master-0.{{ localDomainSuffix }}
+    shell: nova reboot --hard "{{ master0 }}"
 
   - pause:
       seconds: 40
 
   - name: Get status of master-0
-    shell: oc get node | grep master-0 | awk '{ print $2 }' | cut -d , -f 1
-    register: master0
-    until: master0.stdout == "Ready"
+    shell: oc get node | grep "{{ master0 }}"  | awk '{ print $2 }' | cut -d , -f 1
+    register: master0status
+    until: master0status.stdout == "Ready"
     delay: 5
     retries: 5
 
   - name: reboot master-1
-    shell: nova reboot --hard master-1.{{ localDomainSuffix }}  
+    shell: nova reboot --hard "{{ master1 }}" 
 
   - pause:
       seconds: 40
  
   - name: Get status of master-1
-    shell: oc get node | grep master-1 | awk '{ print $2 }' | cut -d , -f 1
-    register: master1
-    until: master1.stdout == "Ready"
+    shell: oc get node | grep "{{ master1 }}" | awk '{ print $2 }' | cut -d , -f 1
+    register: master1status
+    until: master1status.stdout == "Ready"
     delay: 5
     retries: 5
 
   - name: reboot master-2
-    shell: nova reboot --hard master-2.{{ localDomainSuffix }}
+    shell: nova reboot --hard "{{ master2 }}"
 
   - pause:
       seconds: 40
 
   - name: Get status of master-2
-    shell: oc get node | grep master-2 | awk '{ print $2 }' | cut -d , -f 1
-    register: master2
-    until: master2.stdout == "Ready"
+    shell: oc get node | grep "{{ master2 }}" | awk '{ print $2 }' | cut -d , -f 1
+    register: master2status
+    until: master2status.stdout == "Ready"
     delay: 5
     retries: 5

--- a/tests/haproxy/node_rotate.yml
+++ b/tests/haproxy/node_rotate.yml
@@ -1,0 +1,48 @@
+# This file sets environment variables needed to run openstack commands on the bastion and then brings down the master nodes in turn, waiting until the last one comes up to bring down the next.
+- hosts: localhost
+  environment:
+    OS_AUTH_URL: "{{ openshift_cloudprovider_openstack_auth_url }}"
+    OS_TENANT_ID: "{{ osTenantId }}"
+    OS_TENANT_NAME: "{{ osTenantName }}"
+    OS_USERNAME: "{{ openstackOpenshiftUsername }}"
+    OS_PASSWORD: "{{ openstackOpenshiftPassword }}"
+  
+  tasks:
+  - name: reboot master-0
+    shell: nova reboot --hard master-0.{{ localDomainSuffix }}
+
+  - pause:
+      seconds: 40
+
+  - name: Get status of master-0
+    shell: oc get node | grep master-0 | awk '{ print $2 }' | cut -d , -f 1
+    register: master0
+    until: master0.stdout == "Ready"
+    delay: 5
+    retries: 5
+
+  - name: reboot master-1
+    shell: nova reboot --hard master-1.{{ localDomainSuffix }}  
+
+  - pause:
+      seconds: 40
+ 
+  - name: Get status of master-1
+    shell: oc get node | grep master-1 | awk '{ print $2 }' | cut -d , -f 1
+    register: master1
+    until: master1.stdout == "Ready"
+    delay: 5
+    retries: 5
+
+  - name: reboot master-2
+    shell: nova reboot --hard master-2.{{ localDomainSuffix }}
+
+  - pause:
+      seconds: 40
+
+  - name: Get status of master-2
+    shell: oc get node | grep master-2 | awk '{ print $2 }' | cut -d , -f 1
+    register: master2
+    until: master2.stdout == "Ready"
+    delay: 5
+    retries: 5

--- a/tests/haproxy/poll.yml
+++ b/tests/haproxy/poll.yml
@@ -1,0 +1,4 @@
+# This runs the poll role against the API endpoint to generate traffic for haproxy test.
+- hosts: localhost
+  roles:
+  - poll

--- a/tests/haproxy/roles/poll/tasks/main.yml
+++ b/tests/haproxy/roles/poll/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: "Test http connection of external cluster IP on port 8443"
+  uri:
+    url: https://ocp.{{ domainSuffix }}:8443/healthz/ping
+    return_content: yes
+    validate_certs: no
+    timeout: 1
+  register: results
+  with_sequence: start=0 end=1000


### PR DESCRIPTION
atomic-openshift-api timeout values changed to improve haproxy failover time when a node goes down. Test written to verify this inside the Jenkins pipeline written that polls the cluster and brings down masters in turn. Passed through the pipeline successfully yesterday and behaved as expected.
