### PR TITLE
Feature/registry cert

### DIFF
--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -44,7 +44,7 @@
   when: inventory_hostname == groups.loadbalancers[0]
 
 - name: Run certbot
-  command: certbot certonly -m openshift@ukcloud.com --standalone -d ocp.{{ domainSuffix }},hawkular-metrics.{{ domainSuffix }},registry-console.{{ domainSuffix }},kibana.{{ domainSuffix }} --agree-tos -n
+  command: certbot certonly -m openshift@ukcloud.com --standalone -d ocp.{{ domainSuffix }},hawkular-metrics.{{ domainSuffix }},registry-console-default.{{ domainSuffix }},kibana.{{ domainSuffix }} --staging --agree-tos -n
   when: inventory_hostname == groups.loadbalancers[0]
 
 - name: Start HAProxy

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -44,7 +44,7 @@
   when: inventory_hostname == groups.loadbalancers[0]
 
 - name: Run certbot
-  command: certbot certonly -m openshift@ukcloud.com --standalone -d ocp.{{ domainSuffix }},hawkular-metrics.{{ domainSuffix }},registry-console-default.{{ domainSuffix }},kibana.{{ domainSuffix }} --staging --agree-tos -n
+  command: certbot certonly -m openshift@ukcloud.com --standalone -d ocp.{{ domainSuffix }},hawkular-metrics.{{ domainSuffix }},registry-console-default.{{ domainSuffix }},kibana.{{ domainSuffix }} --agree-tos -n
   when: inventory_hostname == groups.loadbalancers[0]
 
 - name: Start HAProxy

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -35,7 +35,7 @@
   when: getCertificates == True
 
 - name: Move registry.cert across to masters[0]
-  local_action: command scp registry.cert {{ groups.masters[0] }}:/home/cloud-user 
+  local_action: command scp registry.cert cloud-user@{{ groups.masters[0] }}:/home/cloud-user 
   when: getCertificates == True 
 
 - name: Change to default project

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -35,7 +35,11 @@
   when: getCertificates == True
 
 - name: Move registry.cert across to masters[0]
-  local_action: command scp registry.cert cloud-user@{{ groups.masters[0] }}:/home/cloud-user 
+  copy:
+    src: /home/cloud-user/ocp.{{ domainSuffix }}/registry.cert
+    dest: /home/cloud-user/registry.cert
+    owner: cloud-user
+    mode: 0644 
   when: getCertificates == True 
 
 - name: Change to default project

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -31,7 +31,7 @@
   when: installLogging == True
 
 - name: Create registry.cert file
-  local_action: command cd /home/cloud-user/ocp.{{ domainSuffix }} ; cat fullchain1.pem privkey1.pem > registry.cert
+  local_action: shell cd /home/cloud-user/ocp.{{ domainSuffix }} ; cat fullchain1.pem privkey1.pem > registry.cert
   when: getCertificates == True
 
 - name: Move registry.cert across to masters[0]

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -30,3 +30,22 @@
     - openshift
   when: installLogging == True
 
+- name: Create registry.cert file
+  local_action: command cd /home/cloud-user/ocp.{{ domainSuffix }} ; cat fullchain1.pem privkey1.pem > registry.cert
+  when: getCertificates == True
+
+- name: Move registry.cert across to masters[0]
+  local_action: command scp registry.cert {{ groups.masters[0] }}:/home/cloud-user 
+  when: getCertificates == True 
+
+- name: Change to default project
+  command: /usr/local/bin/oc project default
+  when: getCertificates == True
+
+- name: Create registry cert secret
+  command: /usr/local/bin/oc secrets new console-secret /home/cloud-user/registry.cert
+  when: getCertificates == True
+
+- name: Mount secret to registry console container and trigger new deploy
+  command: /usr/local/bin/oc volume dc/registry-console --add --type=secret --secret-name=console-secret -m /etc/cockpit/ws-certs.d
+  when: getCertificates == True


### PR DESCRIPTION
Postdeployment steps added to create a file with cert,cafile and privkey from letsencrypt and then mount this as a secret to the registry console pod triggering a new deploy with the custom certs.