### PR TITLE
Taints and tolerations

### DIFF
--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -190,7 +190,7 @@ nodes_net2
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra:true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra':'true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% for ip, hostname in worker_details_internet.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'internet':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -32,6 +32,12 @@ openshift_release=v{{ openshiftVersion }}
 
 openshift_set_hostname=true
 
+{% if multinetwork %}
+# Adding buildoverride values to make build pods target infra nodes in multi-network deployments
+openshift_buildoverrides_nodeselectors={'build':'true'}
+openshift_buildoverrides_tolerations=[{'key':'infra','value':'only','effect':'NoSchedule','operator':'Equal'}]
+{% endif %}
+
 # Makes the openshift_ip setting in the host groups are below take effect.
 # This sets the nodeIP setting in node-config on each host to the correct IP
 openshift_set_node_ip=true
@@ -178,24 +184,51 @@ nodes_internet
 {% if multinetwork %}
 nodes_net2
 {% endif %}
+nodes_infra
+nodes_tenant
+nodes_master
 
 [nodes_internet]
 {% for ip, hostname in master_details.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','network':'internet','purpose':'infra','failure-domain.beta.kubernetes.io/zone':'nova'}"
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','net2':'true','tenant':'true','infra':'true','build':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% for ip, hostname in worker_details_internet.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'network':'internet','purpose':'tenant','failure-domain.beta.kubernetes.io/zone':'nova'}"
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'internet':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
+{% endfor %}
+
+[nodes_infra]
+{% for ip, hostname in infrastructure_node_details.items() %}
+{{ hostname }}
 {% endfor %}
 
 [nodes_net2]
 {% if multinetwork %}
 {% for ip, hostname in worker_details_net2.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'secondary','network':'net2','purpose':'tenant','failure-domain.beta.kubernetes.io/zone':'nova'}"
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'secondary','net2':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% endif %}
+
+[nodes_infra]
+{% for ip, hostname in infrastructure_node_details.items() %}
+{{ hostname }}
+{% endfor %}
+
+[nodes_tenant]
+{% for ip, hostname in worker_details_internet.items() %}
+{{ hostname }}
+{% endfor %}
+{% if multinetwork %}
+{% for ip, hostname in worker_details_net2.items() %}
+{{ hostname }}
+{% endfor %}
+
+[nodes_master]
+{% for ip, hostname in master_details.items() %}
+{{ hostname }}
+{% endfor %}
 
 # groups to capture all of the hosts with connectivity to each network connection
 [internet_all:children]

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -51,7 +51,7 @@ openshift_docker_options="--mtu=1400  --log-driver=journald"
 openshift_hosted_router_selector='router=true'
 
 # REGISTRY
-openshift_hosted_registry_selector='purpose=infra'
+openshift_hosted_registry_selector='infra=true'
 openshift_hosted_registry_replicas=1
 #openshift_hosted_registry_storage_kind=openstack
 #openshift_hosted_registry_storage_access_modes=['ReadWriteOnce']
@@ -76,7 +76,7 @@ openshift_hosted_registry_acceptschema2=true
 openshift_hosted_registry_enforcequota=true
 
 
-osm_default_node_selector='purpose=tenant'
+osm_default_node_selector='tenant=true'
 
 # enable ntp on masters to ensure proper failover
 openshift_clock_enabled=true
@@ -102,9 +102,9 @@ openshift_hosted_metrics_public_url=https://hawkular-metrics.{{ domainSuffix }}/
 openshift_hosted_metrics_storage_kind=dynamic
 openshift_metrics_cassandra_pvc_size=10Gi
 # Node selectors for hawkular metrics
-openshift_metrics_cassandra_nodeselector={"purpose":"infra"}
-openshift_metrics_hawkular_nodeselector={"purpose":"infra"}
-openshift_metrics_heapster_nodeselector={"purpose":"infra"}
+openshift_metrics_cassandra_nodeselector={"infra":"true"}
+openshift_metrics_hawkular_nodeselector={"infra":"true"}
+openshift_metrics_heapster_nodeselector={"infra":"true"}
 
 # openshift aggregated logging deployment - comment out if no aggregated logging  deployment is required. this will run on the worker nodes
 openshift_logging_install_logging={{ installLogging  }}
@@ -120,13 +120,13 @@ openshift_logging_use_ops=false
 openshift_logging_es_cluster_size={{ loggingClusterSize }}
 openshift_logging_elasticsearch_pvc_size="20Gi"
 # Node selectors for aggregated logging
-openshift_logging_curator_nodeselector={"purpose":"infra"}
-openshift_logging_kibana_nodeselector={"purpose":"infra"}
-openshift_logging_es_nodeselector={"purpose":"infra"}
+openshift_logging_curator_nodeselector={"infra":"true"}
+openshift_logging_kibana_nodeselector={"infra":"true"}
+openshift_logging_es_nodeselector={"infra":"true"}
 
 # fix to make the ansible service broker deploy to the correct nodes rather than all or none
 # RH ticket #02020379
-template_service_broker_selector={"purpose":"infra"}
+template_service_broker_selector={"infra":"true"}
 
 # Create an OSEv3 group that contains the masters and nodes groups
 # host group for masters

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -184,9 +184,6 @@ nodes_internet
 {% if multinetwork %}
 nodes_net2
 {% endif %}
-nodes_infra
-nodes_tenant
-nodes_master
 
 [nodes_internet]
 {% for ip, hostname in master_details.items() %}
@@ -199,36 +196,12 @@ nodes_master
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'internet':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 
-[nodes_infra]
-{% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }}
-{% endfor %}
-
 [nodes_net2]
 {% if multinetwork %}
 {% for ip, hostname in worker_details_net2.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'secondary','net2':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% endif %}
-
-[nodes_infra]
-{% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }}
-{% endfor %}
-
-[nodes_tenant]
-{% for ip, hostname in worker_details_internet.items() %}
-{{ hostname }}
-{% endfor %}
-{% if multinetwork %}
-{% for ip, hostname in worker_details_net2.items() %}
-{{ hostname }}
-{% endfor %}
-
-[nodes_master]
-{% for ip, hostname in master_details.items() %}
-{{ hostname }}
-{% endfor %}
 
 # groups to capture all of the hosts with connectivity to each network connection
 [internet_all:children]

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -190,7 +190,7 @@ nodes_net2
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','net2':'true','tenant':'true','infra':'true','build':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra:true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% for ip, hostname in worker_details_internet.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'internet':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -67,3 +67,9 @@
     net2_scale: "{{ groups['nodes_net2'] | length }}"
   command: /usr/local/bin/oc scale dc router-secondary --replicas={{ net2_scale }}
   when: multinetwork
+
+- name: taint infrastructure nodes to prevent customer applications scheduling
+  command: /usr/local/bin/oc adm taint node "{{ item }}" infra=only:NoSchedule
+  with_items:
+    - "{{ groups.nodes_infra }}"
+  when: multinetwork

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -71,5 +71,5 @@
 - name: taint infrastructure nodes to prevent customer applications scheduling
   command: /usr/local/bin/oc adm taint node "{{ item }}" infra=only:NoSchedule
   with_items:
-    - "{{ infrastructure_nodes_details.values() }}"
+    - "{{ infrastructure_node_details.values() }}"
   when: multinetwork

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -71,5 +71,5 @@
 - name: taint infrastructure nodes to prevent customer applications scheduling
   command: /usr/local/bin/oc adm taint node "{{ item }}" infra=only:NoSchedule
   with_items:
-    - "{{ groups.nodes_infra }}"
+    - "{{ infrastructure_nodes_details.values() }}"
   when: multinetwork


### PR DESCRIPTION
Added variables to our ansible hosts file to set build overrides when multinetwork is true, changes labels across the board to allow our build isolation and also taints infrastructure nodes as a postdeployment task.