### PR TITLE
Minor version

### DIFF
--- a/roles/initialisation/tasks/main.yml
+++ b/roles/initialisation/tasks/main.yml
@@ -3,6 +3,17 @@
     name: bind-utils
     state: latest
 
+- name: Get list of installed packages
+  yum:
+    list=installed
+  register: package_list
+
+- name: Get installed atomic-openshift-utils version
+  set_fact:
+    installed_version: "{{ package_list | json_query(package_filter) }}"
+  vars: 
+    package_filter: "results[?name=='atomic-openshift-utils'].version"
+
 - set_fact:
     admin_password: "{{ lookup('env', 'OPENSHIFT_PASSWORD') }}"
 

--- a/roles/initialisation/tasks/main.yml
+++ b/roles/initialisation/tasks/main.yml
@@ -8,6 +8,8 @@
     list=installed
   register: package_list
 
+# package_list returns json array so json_query below is required to fish relevant data
+
 - name: Get installed atomic-openshift-utils version
   set_fact:
     installed_version: "{{ package_list | json_query(package_filter) }}"

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -29,7 +29,6 @@ openshift_master_cluster_hostname=console.{{ localDomainSuffix }}
 openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 
 openshift_release=v{{ openshiftVersion }}
-# Sets minor version. installed_version returns data as an array so index is required
 openshift_image_tag=v{{ installed_version[0] }} 
 
 openshift_set_hostname=true

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -29,7 +29,7 @@ openshift_master_cluster_hostname=console.{{ localDomainSuffix }}
 openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 
 openshift_release=v{{ openshiftVersion }}
-openshift_image_tag=v3.9.27
+openshift_image_tag=v{{ installed_version }} 
 
 openshift_set_hostname=true
 

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -29,7 +29,7 @@ openshift_master_cluster_hostname=console.{{ localDomainSuffix }}
 openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 
 openshift_release=v{{ openshiftVersion }}
-openshift_image_tag=v{{ installed_version }} 
+openshift_image_tag=v{{ installed_version[0] }} 
 
 openshift_set_hostname=true
 

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -29,6 +29,7 @@ openshift_master_cluster_hostname=console.{{ localDomainSuffix }}
 openshift_master_cluster_public_hostname=ocp.{{ domainSuffix }}
 
 openshift_release=v{{ openshiftVersion }}
+# Sets minor version. installed_version returns data as an array so index is required
 openshift_image_tag=v{{ installed_version[0] }} 
 
 openshift_set_hostname=true

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -75,7 +75,7 @@
   when: multinetwork
 
 - name: Create 'monitoring' serviceaccount for monitoring use
-  shell: /usr/bin/local/oc project openshift-infra && /usr/bin/local/oc create serviceaccount monitoring
+  shell: /usr/local/bin/oc project openshift-infra && /usr/local/bin/oc create serviceaccount monitoring
 
 - name: Give 'monitoring' service account correct permissions
-  command: /usr/bin/local/oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:monitoring
+  command: /usr/local/bin/oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:monitoring

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -73,3 +73,9 @@
   with_items:
     - "{{ infrastructure_node_details.values() }}"
   when: multinetwork
+
+- name: Create 'monitoring' serviceaccount for monitoring use
+  shell: /usr/bin/local/oc project openshift-infra && /usr/bin/local/oc create serviceaccount monitoring
+
+- name: Give 'monitoring' service account correct permissions
+  command: /usr/bin/local/oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:monitoring


### PR DESCRIPTION
Pinning of minor version to match atomic-openshift-utils RPM on bastion and monitoring service account creation in postdeployment