### PR TITLE
Default namespace tolerations added to infra projects

### DIFF
--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -30,6 +30,18 @@
     - openshift
   when: installLogging == True
 
+- name: Add default tolerations to infrastructure namespaces
+  command: /usr/local/bin/oc annotate ns {{ item }} scheduler.alpha.kubernetes.io/defaultTolerations='[{"key":"infra","value":"only","effect":"NoSchedule"}]'
+  with_items:
+    - default
+    - logging
+    - openshift-ansible-service-broker
+    - openshift-infra
+    - openshift-template-service-broker
+    - openshift-web-console
+    - kube-service-catalog
+  when: multinetwork
+
 - name: Create registry.cert file
   local_action: shell cd /home/cloud-user/ocp.{{ domainSuffix }} ; cat fullchain1.pem privkey1.pem > registry.cert
   when: getCertificates == True

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -31,7 +31,7 @@
   when: installLogging == True
 
 - name: Add default tolerations to infrastructure namespaces
-  command: /usr/local/bin/oc annotate ns {{ item }} scheduler.alpha.kubernetes.io/defaultTolerations='[{"key":"infra","value":"only","effect":"NoSchedule"}]'
+  command: /usr/local/bin/oc annotate ns {{ item }} scheduler.alpha.kubernetes.io/defaultTolerations='[{"key":"infra","value":"only","effect":"NoSchedule","operator":"Equal"}]'
   with_items:
     - default
     - logging

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -30,16 +30,14 @@
     - openshift
   when: installLogging == True
 
+- name: Register variable of infra projects
+  shell: /usr/local/bin/oc get projects | grep -v NAME | awk '{ print $1 }'
+  register: projects
+  when: multinetwork
+
 - name: Add default tolerations to infrastructure namespaces
   command: /usr/local/bin/oc annotate ns {{ item }} scheduler.alpha.kubernetes.io/defaultTolerations='[{"key":"infra","value":"only","effect":"NoSchedule","operator":"Equal"}]'
-  with_items:
-    - default
-    - logging
-    - openshift-ansible-service-broker
-    - openshift-infra
-    - openshift-template-service-broker
-    - openshift-web-console
-    - kube-service-catalog
+  with_items: "{{ projects.stdout_lines }}" 
   when: multinetwork
 
 - name: Create registry.cert file

--- a/tests/openshift/multinetwork.yml
+++ b/tests/openshift/multinetwork.yml
@@ -1,3 +1,6 @@
+# This file tests the ability to deploy pods to infrastructure nodes when the correct toleration is given to their namespace.
+# It then verifies that a pod cannot be scheduled once the toleration is removed.
+
 - hosts: masters[0]
   tasks:
 

--- a/tests/openshift/multinetwork.yml
+++ b/tests/openshift/multinetwork.yml
@@ -51,7 +51,7 @@
     when: multinetwork
 
   - name: Ensure deploy pod doesn't schedule
-    shell: /usr/local/bin/oc describe pod $(oc get pods | grep deploy | awk '{ print $1 }') | grep FailedScheduling
+    shell: /usr/local/bin/oc describe pod $(/usr/local/bin/oc get pods | grep deploy | awk '{ print $1 }') | grep FailedScheduling
     register: pod_status
     retries: 10
     delay: 5

--- a/tests/openshift/multinetwork.yml
+++ b/tests/openshift/multinetwork.yml
@@ -1,0 +1,47 @@
+- hosts: masters[0]
+  tasks:
+
+  - name: Create test project
+    command: /usr/local/bin/oc new-project pod-test
+    when: multinetwork
+
+  - name: Apply nodeSelector to project
+    command: /usr/local/bin/oc annotate ns pod-test openshift.io/node-selector="infra=true" --overwrite
+    when: multinetwork
+
+  - name: Apply tolerations to project
+    command: /usr/local/bin/oc annotate ns pod-test scheduler.alpha.kubernetes.io/defaultTolerations='[{"key":"infra","value":"only","effect":"NoSchedule","operator":"Equal"}]'
+    when: multinetwork
+
+  - name: Roll out test app
+    command: /usr/local/bin/oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git
+    when: multinetwork
+
+  - name: Wait until app rolled out successfully
+    command: /usr/local/bin/oc rollout status dc ruby-ex
+    register: app_readiness
+    until: "'successfully rolled out' in app_readiness.stdout"
+    retries: 30
+    delay: 2
+    when: multinetwork
+
+  - name: Confirm pod rolled out to the infra node
+    shell: /usr/local/bin/oc describe pod $(/usr/local/bin/oc get pods | grep -v build | grep -v NAME | awk '{print $1}') | grep Node
+    register: node
+    until: "'infra' in node.stdout"
+    retries: 1
+    delay: 1
+    when: multinetwork
+
+  - name: Clean up app
+    command: /usr/local/bin/oc delete all -l app=ruby-ex
+    delay: 15
+    when: multinetwork
+
+  - name: Switch to default project
+    command: /usr/local/bin/oc project default
+    when: multinetwork
+
+  - name: Remove pod-test project
+    command: /usr/local/bin/oc delete project pod-test
+    when: multinetwork

--- a/tests/openshift/multinetwork.yml
+++ b/tests/openshift/multinetwork.yml
@@ -38,6 +38,28 @@
     delay: 15
     when: multinetwork
 
+  - name: Remove namespace toleration
+    command: /usr/local/bin/oc annotate ns pod-test scheduler.alpha.kubernetes.io/defaultTolerations='' --overwrite
+    when: multinetwork
+
+  - name: Roll out test app
+    command: /usr/local/bin/oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git
+    delay: 30
+    when: multinetwork
+
+  - name: Ensure deploy pod doesn't schedule
+    shell: /usr/local/bin/oc describe pod $(oc get pods | grep deploy | awk '{ print $1 }') | grep FailedScheduling
+    register: pod_status
+    retries: 10
+    delay: 5
+    until: "'PodToleratesNodeTaints' in pod_status.stdout"
+    when: multinetwork
+
+  - name: Clean up app
+    command: /usr/local/bin/oc delete all -l app=ruby-ex
+    delay: 15
+    when: multinetwork
+
   - name: Switch to default project
     command: /usr/local/bin/oc project default
     when: multinetwork


### PR DESCRIPTION
Added a postdeployment task to annotate infra namespaces to allow tolerations to be passed to their pods by default thus allowing infra apps to restart/redeploy successfully.

Also created test playbook which creates a project targeting the infra nodes and proves pods can schedule there when the default namespace level toleration is present but cannot when this toleration is removed.