### PR TITLE
Added {mark} to 'Add upstream DNS servers to bind' tasks for idempotency

### DIFF
--- a/roles/dns/tasks/dns_common.yml
+++ b/roles/dns/tasks/dns_common.yml
@@ -47,7 +47,7 @@
     dest: /etc/named.conf
     backup: yes
     insertafter: "session-keyfile"
-    marker: "        /* ANSIBLE MANAGED BLOCK - upstream DNS */"
+    marker: "        /* {mark} ANSIBLE MANAGED BLOCK - upstream DNS */"
     block: |2
               forward first;
               forwarders { {{ external_dns[0] }}; };

--- a/roles/dns/tasks/dns_forwarder.yml
+++ b/roles/dns/tasks/dns_forwarder.yml
@@ -3,7 +3,7 @@
     dest: /etc/named.conf
     backup: yes
     insertafter: "session-keyfile"
-    marker: "        /* ANSIBLE MANAGED BLOCK - upstream DNS */"
+    marker: "        /* {mark} ANSIBLE MANAGED BLOCK - upstream DNS */"
     block: |2
               forward first;
               forwarders { {{ net2_dns_server[0] }}; };


### PR DESCRIPTION
Blocks will not be duplicated if dns.yaml is run now. They will be replaced if you change anything inside the ansible managed block.