### PR TITLE
Internet nodes can now accept an empty value

### DIFF
--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -193,9 +193,11 @@ nodes_net2
 {% for ip, hostname in infrastructure_node_details.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra':'true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
+{% if worker_details_internet != None %}
 {% for ip, hostname in worker_details_internet.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'internet':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
+{% endif %}
 
 [nodes_net2]
 {% if multinetwork %}


### PR DESCRIPTION
Added an if wrapper around the for statement that will not attempt to iterate over the worker_details_internet if its value is None. Passed manual deployments with 0 internet nodes and 2 and also passed a pipeline test successfully.

Issue #73 