### PR TITLE
Bugfix/remove docker sysconfig mtu

### DIFF
--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -45,10 +45,7 @@ openshift_set_node_ip=true
 
 openshift_master_default_subdomain={{ domainSuffix }}
 
-# Set the MTU size for the Docker0 bridge and docker native containers
-#openshift_docker_options="--mtu=1400  --log-driver=journald"
-
-# Send Docker logs to journald
+# Set Docker log driver to write to journald
 openshift_docker_options="--log-driver=journald"
 
 # ROUTER

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -46,7 +46,10 @@ openshift_set_node_ip=true
 openshift_master_default_subdomain={{ domainSuffix }}
 
 # Set the MTU size for the Docker0 bridge and docker native containers
-openshift_docker_options="--mtu=1400  --log-driver=journald"
+#openshift_docker_options="--mtu=1400  --log-driver=journald"
+
+# Send Docker logs to journald
+openshift_docker_options="--log-driver=journald"
 
 # ROUTER
 openshift_hosted_router_selector='router=true'


### PR DESCRIPTION
No longer required as openshift-ansible handles this based on value of openshift.node.sdn_mtu parameter:  https://github.com/openshift/openshift-ansible/pull/4336/commits/4ef83afdfdf4bf687b64ffb11dd1294ef7f84bf7

Successfully tested a deployment with this removed

Fixes #79 