### PR TITLE
Allow loadbalancers.yml to run after scale down of net2 nodes to 0

### DIFF
--- a/roles/haproxy/templates/haproxy-dataplane.j2
+++ b/roles/haproxy/templates/haproxy-dataplane.j2
@@ -72,9 +72,11 @@ backend atomic-openshift-router-http
       server     {{ hostname }} {{ ip }}:80 check
     {% endfor %}
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
+    {% if groups.nodes_net2 |length > 0 %}
     {% for ip, hostname in worker_details_net2.items() %}
       server     {{ hostname }} {{ ip }}:80 check
     {% endfor %}
+    {% endif %}
     {% else %}
     {% for ip, hostname in infrastructure_node_details.items() %}
       server     {{ hostname }} {{ ip }}:80 check
@@ -102,9 +104,11 @@ backend atomic-openshift-router-ssl
       server     {{ hostname }} {{ ip }}:443 check
     {% endfor %}
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
+    {% if groups.nodes_net2 |length > 0 %}
     {% for ip, hostname in worker_details_net2.items() %}
       server     {{ hostname }} {{ ip }}:443 check
     {% endfor %}
+    {% endif %}
     {% else %}
     {% for ip, hostname in infrastructure_node_details.items() %}
       server     {{ hostname }} {{ ip }}:443 check


### PR DESCRIPTION
Pipeline test completed. Manual test of scenario confirms this works as long as your inventory file is kept consistent with the cluster (e.g. net2 node is removed when scaled down)