### PR TITLE
Feature/add extra gateway dp

### DIFF
--- a/openshift.yml
+++ b/openshift.yml
@@ -7,4 +7,4 @@
 
 - hosts: all
   roles:
-    - allserverspostdeployments
+    - allserverspostdeployment

--- a/openshift.yml
+++ b/openshift.yml
@@ -4,3 +4,7 @@
 - hosts: masters[0]
   roles:
     - openshiftpostdeployment
+
+- hosts: all
+  roles:
+    - allserverspostdeployments

--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Configure iptables on infra nodes for extra gateway
+  iptables:
+    chain: OS_FIREWALL_ALLOW
+    protocol: tcp
+    ctstate: NEW
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+    comment: Open port for extra gateway router
+  with_items:
+    - 7080
+    - 7443
+  when: extra_gateway_vip is defined and inventory_hostname in groups.nodes_infra

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -40,6 +40,19 @@
     state: restarted 
   when: set_node_routes and inventory_hostname != 'localhost'
 
+ name: Configure iptables on infra nodes for extra gateway
+  iptables:
+    chain: OS_FIREWALL_ALLOW
+    protocol: tcp
+    ctstate: NEW
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+    comment: Open port for extra gateway router
+  with_items:
+    - 7080
+    - 7443
+  when: extra_gateway_vip is defined and inventory_hostname in groups.nodes_infra
+
 - name: Tidy up hosts file on bastion
   blockinfile:
     block: |

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -40,19 +40,6 @@
     state: restarted 
   when: set_node_routes and inventory_hostname != 'localhost'
 
-- name: Configure iptables on infra nodes for extra gateway
-  iptables:
-    chain: OS_FIREWALL_ALLOW
-    protocol: tcp
-    ctstate: NEW
-    destination_port: "{{ item }}"
-    jump: ACCEPT
-    comment: Open port for extra gateway router
-  with_items:
-    - 7080
-    - 7443
-  when: extra_gateway_vip is defined and inventory_hostname in groups.nodes_infra
-
 - name: Tidy up hosts file on bastion
   blockinfile:
     block: |

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -40,7 +40,7 @@
     state: restarted 
   when: set_node_routes and inventory_hostname != 'localhost'
 
- name: Configure iptables on infra nodes for extra gateway
+- name: Configure iptables on infra nodes for extra gateway
   iptables:
     chain: OS_FIREWALL_ALLOW
     protocol: tcp

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -2,6 +2,7 @@
   yum:
     name: haproxy
     state: latest
+
 - name: Configure haproxy controlplane
   template:
     src: templates/haproxy-controlplane.j2
@@ -9,6 +10,7 @@
     force: yes
     backup: yes
   when: inventory_hostname in groups.loadbalancers_controlplane
+
 - name: Configure haproxy dataplane
   template:
     src: templates/haproxy-dataplane.j2
@@ -16,6 +18,7 @@
     force: yes
     backup: yes
   when: inventory_hostname in groups.loadbalancers_dataplane
+
 - name: Update rsyslog config
   blockinfile:
     dest: /etc/rsyslog.conf
@@ -26,12 +29,24 @@
       $UDPServerAddress 127.0.0.1
       # Save haproxy logs to haproxy.log
       local2.* /var/log/haproxy.log
+
+- name: Allow port 7443 and 7080 to use httpd
+  command: semanage port -a -t http_port_t -p tcp "{{ item }}"
+  become: true
+  with_items:
+    - 7443
+    - 7080
+  when: inventory_hostname in groups.loadbalancers_dataplane
+
 - name: Enable haproxy
   command: systemctl enable haproxy
+
 - name: Restart haproxy
   command: systemctl restart haproxy
+
 - name: Restart rsyslog
   command: systemctl restart rsyslog
+
 - name: setup firewall - http
   firewalld:
     service: http
@@ -40,6 +55,7 @@
     zone: public
     state: enabled
   when: inventory_hostname in groups.loadbalancers
+
 - name: setup firewall - https
   firewalld:
     service: https
@@ -48,6 +64,7 @@
     zone: public
     state: enabled
   when: inventory_hostname in groups.loadbalancers
+
 - name: setup firewall - OpenShift API
   firewalld:
     port: 8443/tcp

--- a/roles/haproxy/templates/haproxy-dataplane.j2
+++ b/roles/haproxy/templates/haproxy-dataplane.j2
@@ -51,18 +51,36 @@ defaults
     maxconn                 3000
 
 frontend http-in
-    bind *:80
+    bind {{ vip }}:80
     default_backend atomic-openshift-router-http
     mode tcp
     option tcplog
 
 frontend  https-in
-    bind *:443
+    bind {{ vip }}:443
     default_backend atomic-openshift-router-ssl
     mode tcp
     option tcplog
     tcp-request  inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
+
+{% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
+
+frontend http-in-eg
+    bind {{ extra_gateway_vip }}:80
+    default_backend atomic-openshift-router-http-eg
+    mode tcp
+    option tcplog
+
+frontend  https-in-eg
+    bind {{ extra_gateway_vip }}:443
+    default_backend atomic-openshift-router-ssl-eg
+    mode tcp
+    option tcplog
+    tcp-request  inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+
+{% endif %}
 
 backend atomic-openshift-router-http
     balance source
@@ -114,3 +132,36 @@ backend atomic-openshift-router-ssl
       server     {{ hostname }} {{ ip }}:443 check
     {% endfor %}
     {% endif %}
+
+
+{% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
+
+backend atomic-openshift-router-http-eg
+    balance source
+    mode tcp
+    {% for ip, hostname in infrastructure_node_details.items() %}
+      server     {{ hostname }} {{ ip }}:7080 check
+    {% endfor %}
+
+backend atomic-openshift-router-ssl-eg
+    balance source
+    mode tcp
+    # maximum SSL session ID length is 32 bytes.
+    stick-table type binary len 32 size 30k expire 30m
+    acl clienthello req_ssl_hello_type 1
+    acl serverhello rep_ssl_hello_type 2
+    # use tcp content accepts to detects ssl client and server hello.
+    tcp-request inspect-delay 5s
+    tcp-request content accept if clienthello
+    # no timeout on response inspect delay by default.
+    tcp-response content accept if serverhello
+    stick on payload_lv(43,1) if clienthello
+    # Learn on response if server hello.
+    stick store-response payload_lv(43,1) if serverhello
+    option ssl-hello-chk
+    {% for ip, hostname in infrastructure_node_details.items() %}
+      server     {{ hostname }} {{ ip }}:7443 check
+    {% endfor %}
+
+
+{% endif %}

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -202,7 +202,7 @@ nodes_net2
 
 [nodes_infra]
 {% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra':'true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra':'true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}{% if extra_gateway_vip is defined %}'router-private':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 
 [nodes_net2]

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -185,6 +185,7 @@ loadbalancers_net2_dataplane
 # Routers are placed only on first 3 workers
 [nodes:children]
 nodes_internet
+nodes_infra
 {% if multinetwork %}
 nodes_net2
 {% endif %}
@@ -193,14 +194,16 @@ nodes_net2
 {% for ip, hostname in master_details.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
-{% for ip, hostname in infrastructure_node_details.items() %}
-{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra':'true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
-{% endfor %}
 {% if worker_details_internet != None %}
 {% for ip, hostname in worker_details_internet.items() %}
 {{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'internet':'true','tenant':'true','failure-domain.beta.kubernetes.io/zone':'nova'}"
 {% endfor %}
 {% endif %}
+
+[nodes_infra]
+{% for ip, hostname in infrastructure_node_details.items() %}
+{{ hostname }} openshift_ip={{ ip }} openshift_node_labels="{'router':'true','internet':'true','infra':'true',{% if multinetwork %}'net2':'true','tenant':'true','build':'true',{% endif %}'failure-domain.beta.kubernetes.io/zone':'nova'}"
+{% endfor %}
 
 [nodes_net2]
 {% if multinetwork %}
@@ -214,6 +217,7 @@ nodes_net2
 loadbalancers_controlplane
 loadbalancers_internet_dataplane
 nodes_internet
+nodes_infra
 
 [net2_all:children]
 loadbalancers_net2_dataplane

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -16,7 +16,7 @@ debug_level=2
 # If ansible_ssh_user is not root, ansible_become must be set to true
 #ansible_become=true
 
-deployment_type=openshift-enterprise
+openshift_deployment_type=openshift-enterprise
 
 os_sdn_network_plugin_name=redhat/openshift-ovs-multitenant
 

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -25,3 +25,24 @@ vrrp_instance VI_1 {
         chk_haproxy
     }
 }
+
+{% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
+vrrp_instance VI_2 {
+    state {% if ansible_hostname in primary %}BACKUP
+    {% else %}MASTER
+    {% endif %}interface eth0
+    virtual_router_id 52
+    priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 101 on haproxy, 100 on haproxy2
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass "{{ hostvars[groups.loadbalancers_controlplane[0]].keepalived_password.stdout }}"
+    }
+    virtual_ipaddress {
+        {{ extra_gateway_vip }} dev eth0
+    }
+    track_script {
+        chk_haproxy
+    }
+}
+{% endif %}

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -69,7 +69,7 @@
   when: multinetwork
 
 - name: Setup secondary network router envs
-  command: /usr/local/bin/oc set env dc/router-secondary ROUTE_LABELS="router=secondary"
+  command: /usr/local/bin/oc set env dc/router-secondary ROUTE_LABELS="router-secondary=true"
   when: multinetwork
 
 - name: Scale up secondary network routers

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -12,9 +12,9 @@
     force: yes
     backup: yes
 
-#- name: create tier-1 class 
-#  command: /usr/local/bin/oc create -f ~/storage-class-tier1.yml
-#
+- name: create tier-1 class 
+  command: /usr/local/bin/oc create -f ~/storage-class-tier1.yml
+
 #- name: create tier-2 class 
 #  command: /usr/local/bin/oc create -f ~/storage-class-tier2.yml
 

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -78,6 +78,27 @@
   command: /usr/local/bin/oc scale dc router-secondary --replicas={{ net2_scale }}
   when: multinetwork
 
+- name: Setup routers for private networks (extra gateway)
+  command: /usr/local/bin/oc adm router router-private --replicas=0 --selector='router-private=true' --service-account=router --stats-port=1937 --ports='7080:7080,7443:7443' -n default
+  when: extra_gateway_vip is defined
+
+- name: Setup private network router environment
+  command: /usr/local/bin/oc set env dc/router-private {{ item }} -n default
+  with_items:
+    - ROUTER_SERVICE_HTTP_PORT=7080
+    - ROUTER_SERVICE_HTTPS_PORT=7443
+    - ROUTE_LABELS="router-private=true"
+  when: extra_gateway_vip is defined
+
+- name: Scale up private network routers
+  command: /usr/local/bin/oc scale dc router-private --replicas=2 -n default
+  when: extra_gateway_vip is defined
+
+- name: label nodes for private network routers
+  command: /usr/local/bin/oc label node {{ item }}  'router-private=true'
+  with_items: "{{ infrastructure_node_details.values() }}"
+  when: extra_gateway_vip is defined
+
 - name: taint infrastructure nodes to prevent customer applications scheduling
   command: /usr/local/bin/oc adm taint node "{{ item }}" infra=only:NoSchedule
   with_items:

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -91,12 +91,9 @@
   when: extra_gateway_vip is defined
 
 - name: Scale up private network routers
-  command: /usr/local/bin/oc scale dc router-private --replicas=2 -n default
-  when: extra_gateway_vip is defined
-
-- name: label nodes for private network routers
-  command: /usr/local/bin/oc label node {{ item }}  'router-private=true'
-  with_items: "{{ infrastructure_node_details.values() }}"
+  vars:
+    infra_scale: "{{ groups['nodes_infra'] | length }}"
+  command: /usr/local/bin/oc scale dc router-private --replicas={{ infra_scale }} -n default
   when: extra_gateway_vip is defined
 
 - name: taint infrastructure nodes to prevent customer applications scheduling


### PR DESCRIPTION
Add extra floating IP for use as an additional dataplane on the extra gateway network (usually a private network like a VRF). Also adds the routers in openshift that are required to route the traffic in the cluster.