### PR TITLE
Bugfix for postdeployment task order

### DIFF
--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -79,10 +79,6 @@
   command: /usr/local/bin/oc env dc/router-secondary ROUTER_USE_PROXY_PROTOCOL=true
   when: multinetwork
 
-- name: Allow Source IP to be received on private router from HAProxy
-  command: /usr/local/bin/oc env dc/router-private ROUTER_USE_PROXY_PROTOCOL=true
-  when: extra_gateway_vip is defined
-
 - name: Scale up secondary network routers
   vars:
     net2_scale: "{{ groups['nodes_net2'] | length }}"
@@ -105,6 +101,10 @@
   vars:
     infra_scale: "{{ groups['nodes_infra'] | length }}"
   command: /usr/local/bin/oc scale dc router-private --replicas={{ infra_scale }} -n default
+  when: extra_gateway_vip is defined
+
+- name: Allow Source IP to be received on private router from HAProxy
+  command: /usr/local/bin/oc env dc/router-private ROUTER_USE_PROXY_PROTOCOL=true
   when: extra_gateway_vip is defined
 
 - name: taint infrastructure nodes to prevent customer applications scheduling


### PR DESCRIPTION
router-private environment command was in postdeployment before router-private dc is created causing failures when deploying an extra gateway. Re-ordered tasks to resolve issue.