### PR TITLE
Feature/block root ssh

### DIFF
--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -11,14 +11,14 @@
     - 7443
   when: extra_gateway_vip is defined and inventory_hostname in groups.nodes_infra
 
-  - name: Block root login via SSH to all instances
-    replace:
-      path: /etc/ssh/sshd_config
-      regexp: '^.*PermitRootLogin.*$'
-      replace: 'PermitRootLogin no'
+- name: Block root login via SSH to all instances
+  replace:
+    path: /etc/ssh/sshd_config
+    regexp: '^.*PermitRootLogin.*$'
+    replace: 'PermitRootLogin no'
 
-  - name: Reload sshd service to apply changes
-    systemd:
-      state: reloaded
-      name: sshd
+- name: Reload sshd service to apply changes
+  systemd:
+    state: reloaded
+    name: sshd
  

--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -10,3 +10,15 @@
     - 7080
     - 7443
   when: extra_gateway_vip is defined and inventory_hostname in groups.nodes_infra
+
+  - name: Block root login via SSH to all instances
+    replace:
+      path: /etc/ssh/sshd_config
+      regexp: '^.*PermitRootLogin.*$'
+      replace: 'PermitRootLogin no'
+
+  - name: Reload sshd service to apply changes
+    systemd:
+      state: reloaded
+      name: sshd
+ 

--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -14,8 +14,9 @@
 - name: Block root login via SSH to all instances
   replace:
     path: /etc/ssh/sshd_config
-    regexp: '^.*PermitRootLogin.*$'
+    regexp: '^.PermitRootLogin.*$|^PermitRootLogin.*$'
     replace: 'PermitRootLogin no'
+    backup: yes
 
 - name: Reload sshd service to apply changes
   systemd:

--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Block root login via SSH to all instances
   replace:
     path: /etc/ssh/sshd_config
-    regexp: '^.PermitRootLogin.*$|^PermitRootLogin.*$'
+    regexp: '^.?PermitRootLogin.*$'
     replace: 'PermitRootLogin no'
     backup: yes
 


### PR DESCRIPTION
Adds a postedeployment task that blocks root access via SSH. Tested in a deployment. If approved and merged I will cherrypick the commit to v3.11 branch too.