### PR TITLE
Secondary router move

### DIFF
--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -20,8 +20,8 @@
     jump: ACCEPT
     comment: Open port for secondary network router
   with_items:
-    - 6080
-    - 6443
+    - 5080
+    - 5443
   when: multinetwork and inventory_hostname in groups.nodes_infra
 
 - name: Block root login via SSH to all instances

--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -11,6 +11,19 @@
     - 7443
   when: extra_gateway_vip is defined and inventory_hostname in groups.nodes_infra
 
+- name: Configure iptables on infra nodes for secondary network
+  iptables:
+    chain: OS_FIREWALL_ALLOW
+    protocol: tcp
+    ctstate: NEW
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+    comment: Open port for secondary network router
+  with_items:
+    - 6080
+    - 6443
+  when: multinetwork and inventory_hostname in groups.nodes_infra
+
 - name: Block root login via SSH to all instances
   replace:
     path: /etc/ssh/sshd_config

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -38,6 +38,14 @@
     - 7080
   when: inventory_hostname in groups.loadbalancers_dataplane
 
+- name: Allow port 6443 and 6080 to use httpd
+  command: semanage port -a -t http_port_t -p tcp "{{ item }}"
+  become: true
+  with_items:
+    - 6443
+    - 6080
+  when: inventory_hostname in groups.loadbalancers_net2_dataplane
+
 - name: Enable haproxy
   command: systemctl enable haproxy
 

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -39,13 +39,13 @@
     - 7080
   when: inventory_hostname in groups.loadbalancers_dataplane
 
-- name: Allow port 6443 and 6080 to use httpd
+- name: Allow port 5443 and 5080 to use httpd
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true
   ignore_errors: true
   with_items:
-    - 6443
-    - 6080
+    - 5443
+    - 5080
   when: inventory_hostname in groups.loadbalancers_net2_dataplane
 
 - name: Enable haproxy

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -33,7 +33,6 @@
 - name: Allow port 7443 and 7080 to use httpd
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true
-  ignore_errors: true
   with_items:
     - 7443
     - 7080
@@ -42,7 +41,6 @@
 - name: Allow port 6443 and 6080 to use httpd
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true
-  ignore_errors: true
   with_items:
     - 6443
     - 6080

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -38,7 +38,7 @@
     - 7080
   when: inventory_hostname in groups.loadbalancers_dataplane
 
-- name: Allow port 5443 and 5080 to use httpd
+- name: Allow port 5443 and 5080 to use http
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true
   with_items:

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -33,6 +33,7 @@
 - name: Allow port 7443 and 7080 to use httpd
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true
+  ignore_errors: true
   with_items:
     - 7443
     - 7080
@@ -41,6 +42,7 @@
 - name: Allow port 6443 and 6080 to use httpd
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true
+  ignore_errors: true
   with_items:
     - 6443
     - 6080

--- a/roles/haproxy/templates/haproxy-dataplane.j2
+++ b/roles/haproxy/templates/haproxy-dataplane.j2
@@ -90,9 +90,8 @@ backend atomic-openshift-router-http
       server     {{ hostname }} {{ ip }}:80 check send-proxy-v2
     {% endfor %}
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
-    {% if groups.nodes_net2 |length > 0 %}
-    {% for ip, hostname in worker_details_net2.items() %}
-      server     {{ hostname }} {{ ip }}:80 check send-proxy-v2
+    {% for ip, hostname in infrastructure_node_details.items() %}
+      server     {{ hostname }} {{ ip }}:6080 check send-proxy-v2
     {% endfor %}
     {% endif %}
     {% else %}
@@ -122,9 +121,8 @@ backend atomic-openshift-router-ssl
       server     {{ hostname }} {{ ip }}:443 check send-proxy-v2-ssl
     {% endfor %}
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
-    {% if groups.nodes_net2 |length > 0 %}
-    {% for ip, hostname in worker_details_net2.items() %}
-      server     {{ hostname }} {{ ip }}:443 check send-proxy-v2-ssl
+    {% for ip, hostname in infrastructure_node_details.items() %}
+      server     {{ hostname }} {{ ip }}:6443 check send-proxy-v2-ssl
     {% endfor %}
     {% endif %}
     {% else %}

--- a/roles/haproxy/templates/haproxy-dataplane.j2
+++ b/roles/haproxy/templates/haproxy-dataplane.j2
@@ -91,7 +91,7 @@ backend atomic-openshift-router-http
     {% endfor %}
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
     {% for ip, hostname in infrastructure_node_details.items() %}
-      server     {{ hostname }} {{ ip }}:6080 check send-proxy-v2
+      server     {{ hostname }} {{ ip }}:5080 check send-proxy-v2
     {% endfor %}
     {% endif %} 
  
@@ -117,7 +117,7 @@ backend atomic-openshift-router-ssl
     {% endfor %}
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
     {% for ip, hostname in infrastructure_node_details.items() %}
-      server     {{ hostname }} {{ ip }}:6443 check send-proxy-v2-ssl
+      server     {{ hostname }} {{ ip }}:5443 check send-proxy-v2-ssl
     {% endfor %}
     {% endif %}
 

--- a/roles/haproxy/templates/haproxy-dataplane.j2
+++ b/roles/haproxy/templates/haproxy-dataplane.j2
@@ -93,11 +93,6 @@ backend atomic-openshift-router-http
     {% for ip, hostname in infrastructure_node_details.items() %}
       server     {{ hostname }} {{ ip }}:6080 check send-proxy-v2
     {% endfor %}
-    {% endif %}
-    {% else %}
-    {% for ip, hostname in infrastructure_node_details.items() %}
-      server     {{ hostname }} {{ ip }}:80 check send-proxy-v2
-    {% endfor %}
     {% endif %} 
  
 backend atomic-openshift-router-ssl
@@ -123,11 +118,6 @@ backend atomic-openshift-router-ssl
     {% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}
     {% for ip, hostname in infrastructure_node_details.items() %}
       server     {{ hostname }} {{ ip }}:6443 check send-proxy-v2-ssl
-    {% endfor %}
-    {% endif %}
-    {% else %}
-    {% for ip, hostname in infrastructure_node_details.items() %}
-      server     {{ hostname }} {{ ip }}:443 check send-proxy-v2-ssl
     {% endfor %}
     {% endif %}
 

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -136,7 +136,7 @@ template_service_broker_selector={"node-role.kubernetes.io/infra":"true"}
 ansible_service_broker_node_selector={"node-role.kubernetes.io/infra":"true"}
 
 ### Setup the default node labels for each node type
-openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']},{'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true','internet=true','infra=true','router=true'{% if extra_gateway_vip is defined %},'router-private=true'{% endif %}{% if multinetwork %},'net2=true','build=true','tenant=true'{% endif %}]},{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true','internet=true','tenant=true']},{'name': 'node-config-compute-net2', 'labels': ['node-role.kubernetes.io/compute=true','router=secondary','net2=true','tenant=true']}]
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']},{'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true','internet=true','infra=true','router=true'{% if multinetwork},'router-secondary=true'{%endif}{% if extra_gateway_vip is defined %},'router-private=true'{% endif %}{% if multinetwork %},'net2=true','build=true','tenant=true'{% endif %}]},{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true','internet=true','tenant=true']},{'name': 'node-config-compute-net2', 'labels': ['node-role.kubernetes.io/compute=true','net2=true','tenant=true']}]
 
 # Create an OSEv3 group that contains the masters and nodes groups
 # host group for masters

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -136,7 +136,7 @@ template_service_broker_selector={"node-role.kubernetes.io/infra":"true"}
 ansible_service_broker_node_selector={"node-role.kubernetes.io/infra":"true"}
 
 ### Setup the default node labels for each node type
-openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']},{'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true','internet=true','infra=true','router=true'{% if multinetwork},'router-secondary=true'{%endif}{% if extra_gateway_vip is defined %},'router-private=true'{% endif %}{% if multinetwork %},'net2=true','build=true','tenant=true'{% endif %}]},{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true','internet=true','tenant=true']},{'name': 'node-config-compute-net2', 'labels': ['node-role.kubernetes.io/compute=true','net2=true','tenant=true']}]
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']},{'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true','internet=true','infra=true','router=true'{% if multinetwork %},'router-secondary=true'{% endif %}{% if extra_gateway_vip is defined %},'router-private=true'{% endif %}{% if multinetwork %},'net2=true','build=true','tenant=true'{% endif %}]},{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true','internet=true','tenant=true']},{'name': 'node-config-compute-net2', 'labels': ['node-role.kubernetes.io/compute=true','net2=true','tenant=true']}]
 
 # Create an OSEv3 group that contains the masters and nodes groups
 # host group for masters

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -65,14 +65,14 @@
   when: getCertificates == True
 
 - name: Setup secondary network routers
-  command: /usr/local/bin/oc adm router router-secondary --replicas=0 --selector='router=secondary' --service-account=router --stats-port=1938 --ports='6080:6080,6443:6443' -n default
+  command: /usr/local/bin/oc adm router router-secondary --replicas=0 --selector='router=secondary' --service-account=router --stats-port=1938 --ports='5080:5080,5443:5443' -n default
   when: multinetwork
 
 - name: Setup secondary network router environment
   command: /usr/local/bin/oc set env dc/router-secondary {{ item }} -n default
   with_items:
-    - ROUTER_SERVICE_HTTP_PORT=6080
-    - ROUTER_SERVICE_HTTPS_PORT=6443
+    - ROUTER_SERVICE_HTTP_PORT=5080
+    - ROUTER_SERVICE_HTTPS_PORT=5443
     - ROUTE_LABELS="router-secondary=true"
     - ROUTER_SERVICE_NO_SNI_PORT=13443
     - ROUTER_SERVICE_SNI_PORT=13444

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -65,7 +65,7 @@
   when: getCertificates == True
 
 - name: Setup secondary network routers
-  command: /usr/local/bin/oc adm router router-secondary --replicas=0 --selector='router=secondary' --service-account=router --stats-port=1938 --ports='5080:5080,5443:5443' -n default
+  command: /usr/local/bin/oc adm router router-secondary --replicas=0 --selector='router-secondary=true' --service-account=router --stats-port=1938 --ports='5080:5080,5443:5443' -n default
   when: multinetwork
 
 - name: Setup secondary network router environment

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -65,24 +65,27 @@
   when: getCertificates == True
 
 - name: Setup secondary network routers
-  command: /usr/local/bin/oc adm router router-secondary --replicas=0 --selector='router=secondary' --service-account=router
+  command: /usr/local/bin/oc adm router router-secondary --replicas=0 --selector='router=secondary' --service-account=router --stats-port=1938 --ports='6080:6080,6443:6443' -n default
   when: multinetwork
 
-- name: Setup secondary network router envs
-  command: /usr/local/bin/oc set env dc/router-secondary ROUTE_LABELS="router-secondary=true"
+- name: Setup secondary network router environment
+  command: /usr/local/bin/oc set env dc/router-secondary {{ item }} -n default
+  with_items:
+    - ROUTER_SERVICE_HTTP_PORT=6080
+    - ROUTER_SERVICE_HTTPS_PORT=6443
+    - ROUTE_LABELS="router-secondary=true"
+    - ROUTER_SERVICE_NO_SNI_PORT=13443
+    - ROUTER_SERVICE_SNI_PORT=13444
+    - ROUTER_USE_PROXY_PROTOCOL=true
   when: multinetwork
 
 - name: Allow Source IP to be received on primary router from the HAProxy
   command: /usr/local/bin/oc env dc/router ROUTER_USE_PROXY_PROTOCOL=true
 
-- name: Allow Source IP to be received on secondary router from HAProxy
-  command: /usr/local/bin/oc env dc/router-secondary ROUTER_USE_PROXY_PROTOCOL=true
-  when: multinetwork
-
 - name: Scale up secondary network routers
   vars:
-    net2_scale: "{{ groups['nodes_net2'] | length }}"
-  command: /usr/local/bin/oc scale dc router-secondary --replicas={{ net2_scale }}
+    infra_scale: "{{ groups['nodes_infra'] | length }}"
+  command: /usr/local/bin/oc scale dc router-secondary --replicas={{ infra_scale }}
   when: multinetwork
 
 - name: Setup routers for private networks (extra gateway)
@@ -97,16 +100,13 @@
     - ROUTE_LABELS="router-private=true"
     - ROUTER_SERVICE_NO_SNI_PORT=11443
     - ROUTER_SERVICE_SNI_PORT=11444
+    - ROUTER_USE_PROXY_PROTOCOL=true
   when: extra_gateway_vip is defined
 
 - name: Scale up private network routers
   vars:
     infra_scale: "{{ groups['nodes_infra'] | length }}"
   command: /usr/local/bin/oc scale dc router-private --replicas={{ infra_scale }} -n default
-  when: extra_gateway_vip is defined
-
-- name: Allow Source IP to be received on private router from HAProxy
-  command: /usr/local/bin/oc env dc/router-private ROUTER_USE_PROXY_PROTOCOL=true
   when: extra_gateway_vip is defined
 
 - name: taint infrastructure nodes to prevent customer applications scheduling


### PR DESCRIPTION
Allows secondary network router pods to run on the infra nodes rather than net2 nodes