### PR TITLE
Slave zone now updates from dns.yml

### DIFF
--- a/roles/dns/templates/zonefile.j2
+++ b/roles/dns/templates/zonefile.j2
@@ -1,7 +1,7 @@
 $ORIGIN {{ localDomainSuffix }}.
 $TTL 60s 
 @    IN    SOA    dns1.{{ localDomainSuffix }}.    hostmaster.{{ localDomainSuffix }}. (
-            2001062501 ; serial                     
+            {{ ansible_date_time.epoch }} ; serial                     
             21600      ; refresh after 6 hours                     
             3600       ; retry after 1 hour                     
             604800     ; expire after 1 week                     


### PR DESCRIPTION
Changed serial to epoch var. Tested and it works, syntax also looks correct in generated zonefile not off-centre like the template.