### PR TITLE
added retention period variable

### DIFF
--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -123,6 +123,7 @@ openshift_logging_es_nodeselector={"node-role.kubernetes.io/infra":"true"}
 openshift_logging_es_memory_limit="8Gi"
 # Specify newer curator5 image to mitigate https://bugzilla.redhat.com/show_bug.cgi?id=1648453
 openshift_logging_curator_image={{ registryUrl }}/openshift3/ose-logging-curator5:v3.11.59-2
+openshift_logging_curator_default_days=14
 
 # fix to make the ansible service broker deploy to the correct nodes rather than all or none
 # RH ticket #02020379


### PR DESCRIPTION
This passes CURATOR_DEFAULT_DAYS: 14 to the curator jobs that run meaning we have 14 day retention on deployment. Tested on 3.11 deployment.