### PR TITLE
Remove static reference to sa secret name

### DIFF
--- a/roles/openshiftpostdeployment/tasks/squid-whitelist.yml
+++ b/roles/openshiftpostdeployment/tasks/squid-whitelist.yml
@@ -13,10 +13,6 @@
 - name: Apply read-whitelist role to whitelist-reader serviceaccount
   command: /usr/local/bin/oc policy add-role-to-user read-whitelist -z whitelist-reader -n whitelist --role-namespace='whitelist'
 
-- name: Get whitelist-reader serviceaccount token name
-  command: /usr/local/bin/oc get sa -n whitelist -o jsonpath='{$.items[?(@.metadata.name=="whitelist-reader")].secrets[0].name}'
-  register: whitelist_token_name
-
-- name: Extract base64 whitelist-reader token
-  command: /usr/local/bin/oc get secret {{ whitelist_token_name.stdout }} -n whitelist -o jsonpath='{$.data.token}'
+- name: Get first whitelist-reader serviceaccount token
+  command: /usr/local/bin/oc get secrets -n whitelist -o jsonpath='{$.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="whitelist-reader")].data.token}' | /usr/bin/awk '{print $1}'
   register: whitelist_token_b64

--- a/roles/openshiftpostdeployment/tasks/squid-whitelist.yml
+++ b/roles/openshiftpostdeployment/tasks/squid-whitelist.yml
@@ -14,5 +14,5 @@
   command: /usr/local/bin/oc policy add-role-to-user read-whitelist -z whitelist-reader -n whitelist --role-namespace='whitelist'
 
 - name: Get first whitelist-reader serviceaccount token
-  command: /usr/local/bin/oc get secrets -n whitelist -o jsonpath='{$.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="whitelist-reader")].data.token}' | /usr/bin/awk '{print $1}'
+  shell: /usr/local/bin/oc get secrets -o jsonpath='{$.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="whitelist-reader")].data.token}' -n whitelist | /usr/bin/awk '{print $1}'
   register: whitelist_token_b64


### PR DESCRIPTION
Prevents task from creating an empty file (as it occasionally reads the dockercfg secret which doesn't contain a token) and also removes a now redundant step (retrieves token direct from secret as opposed to first retrieving secret name and then retrieving token from specified secret)