### PR TITLE
Journal sizing change

### DIFF
--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -22,6 +22,19 @@
   systemd:
     state: reloaded
     name: sshd
+
+- name: Set journal size to 3G
+  replace:
+    path: /etc/systemd/journald.conf
+    regexp: '^\sSystemMaxUse=.*'
+    replace: ' SystemMaxUse=3G'
+  when: inventory_hostname in groups.nodes and inventory_hostname not in groups.masters
+
+- name: Restart systemd-journald service to implement journal size change
+  service:
+    name: systemd-journald
+    state: restarted
+  when: inventory_hostname in groups.nodes and intventory_hostname not in groups.masters
  
 - include_tasks: squid-whitelist.yml
   when: multinetwork

--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -34,7 +34,7 @@
   service:
     name: systemd-journald
     state: restarted
-  when: inventory_hostname in groups.nodes and intventory_hostname not in groups.masters
+  when: inventory_hostname in groups.nodes and inventory_hostname not in groups.masters
  
 - include_tasks: squid-whitelist.yml
   when: multinetwork


### PR DESCRIPTION
Sets journal size to 3G on all worker nodes (tenant, infra & net2) in postdeployment.