### PR TITLE
bastion upgrade steps re-enabled

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,4 @@
 - import_playbook: all_servers.yml
 - import_playbook: certbot.yml
 - import_playbook: openshift.yml
-# Upgrade bastion being removed for now
-# due to package versioning issues with
-# aggregated logging.
-#- import_playbook: upgrade_bastion.yml
+- import_playbook: upgrade_bastion.yml

--- a/upgrade_bastion.yml
+++ b/upgrade_bastion.yml
@@ -1,13 +1,10 @@
-
 # Upgrade the Bastion host
 # Should happen after deploying the cluster
-# Skip broken added to resolve dependancy issues we are currently facing. 
-# Should be removed when these are fixed via https://bugzilla.redhat.com/show_bug.cgi?id=1497387
 - hosts: localhost
   become: yes
   tasks:
     - name: "Upgrade Bastion Host    (DO NOT interrupt)    ."
-      local_action: yum name=* state=latest skip_broken=yes
+      local_action: yum name=* state=latest
       when: doUpgrades == True
 
     # This isn't the last task in "deploy-with-upgrade", so we can't


### PR DESCRIPTION
Bastion upgraded as part of deployment again. Tested manually and in pipeline. Final reboot step is manual as this allows you to see a full summary of the run and ensure no failures before you reboot.