### PR TITLE
Squid error handling

### DIFF
--- a/roles/openshiftpostdeployment/tasks/squid-whitelist.yml
+++ b/roles/openshiftpostdeployment/tasks/squid-whitelist.yml
@@ -18,7 +18,7 @@
   command: /usr/local/bin/oc create sa whitelist-reader -n whitelist
 
 - name: Create read-whitelist role
-  command: /usr/local/bin/oc create role read-whitelist --verb=get,list --resource=configmaps --resource-name=proxy-whitelist -n whitelist
+  command: /usr/local/bin/oc create role read-whitelist --verb=get,list,patch --resource=configmaps --resource-name=proxy-whitelist -n whitelist
 
 - name: Apply read-whitelist role to whitelist-reader serviceaccount
   command: /usr/local/bin/oc policy add-role-to-user read-whitelist -z whitelist-reader -n whitelist --role-namespace='whitelist'

--- a/roles/squid/templates/whitelist.j2
+++ b/roles/squid/templates/whitelist.j2
@@ -7,5 +7,5 @@ idp.ukcloud.com
 # if you add any the proxy will not reconfigure correctly and any
 # further domains added will not be whitelisted until the offending
 # entries are removed. If a whitelist update fails due to duplicate
-# domains a new key "reconfigure-error" will be added to this configmap
+# domains a new key "whitelist-error" will be added to this configmap
 # containing details on the offending entry

--- a/roles/squid/templates/whitelist.j2
+++ b/roles/squid/templates/whitelist.j2
@@ -6,4 +6,6 @@ idp.ukcloud.com
 # Squid does not support having subdomains of existing domains added
 # if you add any the proxy will not reconfigure correctly and any
 # further domains added will not be whitelisted until the offending
-# entries are removed
+# entries are removed. If a whitelist update fails due to duplicate
+# domains a new key "reconfigure-error" will be added to this configmap
+# containing details on the offending entry

--- a/tools/playbooks/squid-whitelist.yaml
+++ b/tools/playbooks/squid-whitelist.yaml
@@ -1,6 +1,5 @@
 ---
 - hosts: localhost, loadbalancers_controlplane
-  any_errors_fatal: true
   tasks:
   - name: Retrieve whitelist from config-map
     shell: |
@@ -8,6 +7,11 @@
       /usr/bin/oc get configmaps proxy-whitelist -n whitelist -o jsonpath='{.data.proxy-whitelist\.txt}'
     when: inventory_hostname == 'localhost' and multinetwork
     register: proxy_whitelist
+
+  - name: Fail play if task to retrieve whitelist fails
+    fail:
+      msg: "Failing to avoid blank whitelist update"
+    when: hostvars['localhost'].proxy_whitelist.rc != 0
 
   - name: Insert changed block to /etc/squid/sites.whitelist.txt
     blockinfile:
@@ -31,4 +35,6 @@
     - name: reconfigure squid
       command: /usr/sbin/squid -k reconfigure
       become: yes
+      ignore_errors: true
       when: inventory_hostname in groups.loadbalancers_controlplane
+      register: reconfigure_status

--- a/tools/playbooks/squid-whitelist.yaml
+++ b/tools/playbooks/squid-whitelist.yaml
@@ -20,6 +20,13 @@
     notify:
       - reconfigure squid
 
+  - meta: flush_handlers
+
+  - name: Create error configmap if necessary
+    shell: /usr/bin/oc patch cm proxy-whitelist -p '{"data":{"whitelist-error":"{{ reconfigure_status.stderr_lines[0]}}  {{ reconfigure_status.stderr_lines[1]}}"}}' -n whitelist
+    when: reconfigure_status.rc == 1
+    delegate_to: 127.0.0.1
+
   handlers:
     - name: reconfigure squid
       command: /usr/sbin/squid -k reconfigure


### PR DESCRIPTION
Fail task added to capture errors at oc login and avoid blank whitelist update. Failed reconfigures now also populate a configmap in the whitelist project with the relevant error messages for customer. Error format is:

"2019/05/16 22:22:39| ERROR: 'registry.access.redhat.com' is a subdomain of '.redhat.com'\n2019/05/16 22:22:39| ERROR: You need to remove 'registry.access.redhat.com' from the ACL named 'whitelist'\nFATAL: Bungled /etc/squid/squid.conf line 18: acl whitelist dstdomain \"/etc/squid/sites.whitelist.txt\"\nSquid Cache (Version 3.5.20): Terminated abnormally.\nCPU Usage: 0.014 seconds = 0.005 user + 0.009 sys\nMaximum Resident Size: 31392 KB\nPage faults with physical i/o: 0", "stderr_lines": ["2019/05/16 22:22:39| ERROR: 'registry.access.redhat.com' is a subdomain of '.redhat.com'", "2019/05/16 22:22:39| ERROR: You need to remove 'registry.access.redhat.com' from the ACL named 'whitelist'", "FATAL: Bungled /etc/squid/squid.conf line 18: acl whitelist dstdomain \"/etc/squid/sites.whitelist.txt\"", "Squid Cache (Version 3.5.20): Terminated abnormally.", "CPU Usage: 0.014 seconds = 0.005 user + 0.009 sys", "Maximum Resident Size: 31392 KB", "Page faults with physical i/o: 0"


The first and second line which contain relevant error messages will be shown back to the customer:

2019/05/16 22:22:39| ERROR: 'registry.access.redhat.com' is a subdomain of '.redhat.com' 
2019/05/16 22:22:39| ERROR: You need to remove 'registry.access.redhat.com' from the ACL named 'whitelist'
