### PR TITLE
CNAP-931 - Stop Duplicate Logging

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -30,6 +30,14 @@
       # Save haproxy logs to haproxy.log
       local2.* /var/log/haproxy.log
 
+- name: Change rsyslog config to avoid haproxy logs going to messages      
+  lineinfile:
+      path: /etc/rsyslog.conf
+      regexp: '^\*.info;mail.none;authpriv.none;cron.none\s*\/var\/log\/messages'
+      line: '*.info;mail.none;authpriv.none;cron.none;local2.none    /var/log/messages'
+      backrefs: true
+
+
 - name: Allow port 7443 and 7080 to use httpd
   command: semanage port -a -t http_port_t -p tcp "{{ item }}"
   become: true

--- a/roles/haproxy/templates/haproxy-controlplane.j2
+++ b/roles/haproxy/templates/haproxy-controlplane.j2
@@ -16,7 +16,6 @@ global
     #    local2.*                       /var/log/haproxy.log
     #
     log         127.0.0.1 local2
-    log         /dev/log local0 info
 
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid

--- a/roles/haproxy/templates/haproxy-dataplane.j2
+++ b/roles/haproxy/templates/haproxy-dataplane.j2
@@ -16,7 +16,6 @@ global
     #    local2.*                       /var/log/haproxy.log
     #
     log         127.0.0.1 local2
-    log         /dev/log local0 info
 
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid


### PR DESCRIPTION
Remove extra lines from haproxy.conf templates, and stop haproxy logs being sent to messages.

Testing on a 3.11 deployment.