### PR TITLE
Remove curator image from ansible-hosts template

### DIFF
--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -132,8 +132,6 @@ openshift_logging_kibana_nodeselector={"node-role.kubernetes.io/infra":"true"}
 openshift_logging_es_nodeselector={"node-role.kubernetes.io/infra":"true"}
 # Set the default memory limit for elasticsearch so that the pod can be scheduled to an infra node
 openshift_logging_es_memory_limit="8Gi"
-# Specify newer curator5 image to mitigate https://bugzilla.redhat.com/show_bug.cgi?id=1648453
-openshift_logging_curator_image={{ registryUrl }}/openshift3/ose-logging-curator5:v3.11.59-2
 openshift_logging_curator_default_days=14
 
 # fix to make the ansible service broker deploy to the correct nodes rather than all or none


### PR DESCRIPTION
Bug no longer affecting newer images, removing to default to oc version on deployment. Tested curator cronjob runs successfully on v3.11.104