### PR TITLE
Remove allow-update in slave zone since named fails to start in 9.11.4

### DIFF
--- a/roles/dns/templates/slave_zone_config.j2
+++ b/roles/dns/templates/slave_zone_config.j2
@@ -2,7 +2,6 @@ zone"{{ localDomainSuffix }}" IN {
     type slave;
     masters { {{ hostvars[groups.dns[0]].ansible_default_ipv4.address }}; };
     file "{{ localDomainSuffix }}.zone";
-    allow-update { none; };
     allow-transfer { none; };
 };
 


### PR DESCRIPTION
Tested using bind 9.11.4-9 and bind 9.9.4-74