### PR TITLE
Feature/squidvip2

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,7 +12,7 @@
   when: inventory_hostname in groups.internet_all or inventory_hostname == 'localhost'
 
 - name: Set network manager DNS for net2 hosts
-  shell: nmcli c modify 'System eth0' ipv4.ignore-auto-dns yes ipv4.dns {{ hostvars[groups.dns_net2[0]].ansible_eth0.ipv4.address }},{{ hostvars[groups.dns_net2[1]].ansible_eth0.ipv4.address }} ipv4.gateway {{ net2_gateway }} ipv4.address {{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}/24 ipv4.method manual 802-3-ethernet.mtu 1446 && nmcli c up "System eth0"  && touch .set_network_manager_dns
+  shell: nmcli c modify 'System eth0' ipv4.ignore-auto-dns yes ipv4.dns {{ hostvars[groups.dns_net2[0]].ansible_eth0.ipv4.address }},{{ hostvars[groups.dns_net2[1]].ansible_eth0.ipv4.address }} ipv4.gateway {{ net2_gateway }} ipv4.address {{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}/24 ipv4.method manual && nmcli c up "System eth0"  && touch .set_network_manager_dns
   args:
     creates: .set_network_manager_dns
   become: yes

--- a/roles/dns/templates/slave_zone_config.j2
+++ b/roles/dns/templates/slave_zone_config.j2
@@ -2,7 +2,6 @@ zone"{{ localDomainSuffix }}" IN {
     type slave;
     masters { {{ hostvars[groups.dns[0]].ansible_default_ipv4.address }}; };
     file "{{ localDomainSuffix }}.zone";
-    allow-update { none; };
     allow-transfer { none; };
 };
 

--- a/roles/initialisation/tasks/main.yml
+++ b/roles/initialisation/tasks/main.yml
@@ -62,10 +62,10 @@
     force: yes
     backup: yes
 
-- name: Replace OpenStack cloud config template with one supporting new AZ feature
-  become: true
-  copy:
-    src: templates/openstack.conf.j2
-    dest: /usr/share/ansible/openshift-ansible/roles/openshift_cloud_provider/templates/openstack.conf.j2
-    force: yes
-    backup: yes
+#- name: Replace OpenStack cloud config template with one supporting new AZ feature
+#  become: true
+#  copy:
+#    src: templates/openstack.conf.j2
+#    dest: /usr/share/ansible/openshift-ansible/roles/openshift_cloud_provider/templates/openstack.conf.j2
+#    force: yes
+#    backup: yes

--- a/roles/initialisation/tasks/main.yml
+++ b/roles/initialisation/tasks/main.yml
@@ -62,10 +62,3 @@
     force: yes
     backup: yes
 
-#- name: Replace OpenStack cloud config template with one supporting new AZ feature
-#  become: true
-#  copy:
-#    src: templates/openstack.conf.j2
-#    dest: /usr/share/ansible/openshift-ansible/roles/openshift_cloud_provider/templates/openstack.conf.j2
-#    force: yes
-#    backup: yes

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -174,10 +174,10 @@ openshift_http_proxy=http://{{ squid_vip }}:3128
 openshift_https_proxy=http://{{ squid_vip }}:3128
 openshift_no_proxy='.{{ localDomainSuffix }},frn00006.cni.ukcloud.com,cor00005.cni.ukcloud.com,cor00005-2.cni.ukcloud.com,169.254.169.254'
 #openshift_generate_no_proxy_hosts=true
-#openshift_builddefaults_git_http_proxy=http://{{ haproxy_vip }}:3128
-#openshift_builddefaults_git_https_proxy=http://{{ haproxy_vip }}:3128
-#openshift_builddefaults_http_proxy=http://{{ haproxy_vip }}:3128
-#openshift_builddefaults_https_proxy=http://{{ haproxy_vip }}:3128
+#openshift_builddefaults_git_http_proxy=http://{{ squid_vip }}:3128
+#openshift_builddefaults_git_https_proxy=http://{{ squid_vip }}:3128
+#openshift_builddefaults_http_proxy=http://{{ squid_vip }}:3128
+#openshift_builddefaults_https_proxy=http://{{ squid_vip }}:3128
 {% endif %}
 
 ### Setup the default node labels for each node type

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -95,7 +95,7 @@ openshift_cloudprovider_openstack_password={{ openstackOpenshiftPassword }}
 openshift_cloudprovider_openstack_tenant_id={{ osTenantId }}
 openshift_cloudprovider_openstack_tenant_name={{ osTenantName }}
 openshift_cloudprovider_openstack_region={{ osRegion }}
-openshift_cloudprovider_openstack_domain_name:{{ osDomainID }}
+openshift_cloudprovider_openstack_domain_name={{ osDomainID }}
 openshift_cloudprovider_openstack_blockstorage_ignore_volume_az="yes"
 
 # openstack default storage class configuration since this gets created for us regardless now!

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -158,7 +158,7 @@ openshift_cluster_monitoring_operator_alertmanager_storage_capacity="2Gi"
 # Set the v3.11+ console hostname
 openshift_console_hostname=console.{{ domainSuffix }}
 
-{% if ocp_branding is defined and ocp_branding and ocp_branding_url is defined %}
+{% if ocpBranding is defined and ocpBranding and ocpBrandingUrl is defined %}
 # Brand the ocp web console
 openshift_web_console_extension_stylesheet_urls=['{{ ocp_branding_url }}']
 {% endif %}

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -170,9 +170,9 @@ oreg_auth_password={{ registryPassword }}
 
 {% if multinetwork %}
 # Proxy variables for use when net2 deployment is in place
-openshift_http_proxy=http://{{ haproxy_vip }}:3128
-openshift_https_proxy=http://{{ haproxy_vip }}:3128
-openshift_no_proxy='.{{ localDomainSuffix }},frn00006.cni.ukcloud.com,cor00005.cni.ukcloud.com,169.254.169.254'
+openshift_http_proxy=http://{{ squid_vip }}:3128
+openshift_https_proxy=http://{{ squid_vip }}:3128
+openshift_no_proxy='.{{ localDomainSuffix }},frn00006.cni.ukcloud.com,cor00005.cni.ukcloud.com,cor00005-2.cni.ukcloud.com,169.254.169.254'
 #openshift_generate_no_proxy_hosts=true
 #openshift_builddefaults_git_http_proxy=http://{{ haproxy_vip }}:3128
 #openshift_builddefaults_git_https_proxy=http://{{ haproxy_vip }}:3128

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -95,6 +95,7 @@ openshift_cloudprovider_openstack_password={{ openstackOpenshiftPassword }}
 openshift_cloudprovider_openstack_tenant_id={{ osTenantId }}
 openshift_cloudprovider_openstack_tenant_name={{ osTenantName }}
 openshift_cloudprovider_openstack_region={{ osRegion }}
+openshift_cloudprovider_openstack_domain_name:{{ osDomainID }}
 openshift_cloudprovider_openstack_blockstorage_ignore_volume_az="yes"
 
 # openstack default storage class configuration since this gets created for us regardless now!

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -133,8 +133,6 @@ openshift_logging_kibana_nodeselector={"node-role.kubernetes.io/infra":"true"}
 openshift_logging_es_nodeselector={"node-role.kubernetes.io/infra":"true"}
 # Set the default memory limit for elasticsearch so that the pod can be scheduled to an infra node
 openshift_logging_es_memory_limit="8Gi"
-# Specify newer curator5 image to mitigate https://bugzilla.redhat.com/show_bug.cgi?id=1648453
-openshift_logging_curator_image={{ registryUrl }}/openshift3/ose-logging-curator5:v3.11.59-2
 openshift_logging_curator_default_days=14
 
 # fix to make the ansible service broker deploy to the correct nodes rather than all or none

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -160,7 +160,7 @@ openshift_console_hostname=console.{{ domainSuffix }}
 
 {% if ocpBranding is defined and ocpBranding and ocpBrandingUrl is defined %}
 # Brand the ocp web console
-openshift_web_console_extension_stylesheet_urls=['{{ ocp_branding_url }}']
+openshift_web_console_extension_stylesheet_urls=['{{ ocpBrandingUrl }}']
 {% endif %}
 
 # New registry authentication options

--- a/roles/initialisation/templates/ansible-hosts-multimaster.j2
+++ b/roles/initialisation/templates/ansible-hosts-multimaster.j2
@@ -158,6 +158,11 @@ openshift_cluster_monitoring_operator_alertmanager_storage_capacity="2Gi"
 # Set the v3.11+ console hostname
 openshift_console_hostname=console.{{ domainSuffix }}
 
+{% if ocp_branding is defined and ocp_branding and ocp_branding_url is defined %}
+# Brand the ocp web console
+openshift_web_console_extension_stylesheet_urls=['{{ ocp_branding_url }}']
+{% endif %}
+
 # New registry authentication options
 oreg_auth_url={{ registryUrl }}
 oreg_auth_user={{ registryUser }}

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -4,6 +4,12 @@ vrrp_script chk_haproxy {
     weight 2 # add 2 points if OK
 }
 
+vrrp_script chk_squid {
+    script "/usr/bin/killall -0 squid"
+    interval 2 # every 2 seconds
+    weight 2 # add 2 points if OK
+}
+
 vrrp_instance VI_1 {
     state {% if ansible_hostname in primary %}MASTER
     {% else %}BACKUP
@@ -23,13 +29,32 @@ vrrp_instance VI_1 {
     }
 }
 
-{% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
 vrrp_instance VI_2 {
     state {% if ansible_hostname in primary %}BACKUP
     {% else %}MASTER
     {% endif %}interface eth0
     virtual_router_id 52
-    priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 101 on haproxy, 100 on haproxy2
+    priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 100 on haproxy, 101 on haproxy2
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass "{{ hostvars[groups.loadbalancers_controlplane[0]].keepalived_password.stdout }}"
+    }
+    virtual_ipaddress {
+        {{ squid_vip }} dev eth0
+    }
+    track_script {
+        chk_squid
+    }
+}
+
+{% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
+vrrp_instance VI_3 {
+    state {% if ansible_hostname in primary %}BACKUP
+    {% else %}MASTER
+    {% endif %}interface eth0
+    virtual_router_id 53
+    priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 100 on haproxy, 101 on haproxy2
     advert_int 1
     authentication {
         auth_type PASS

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -10,7 +10,7 @@ vrrp_script chk_squid {
     weight 2 # add 2 points if OK
 }
 
-vrrp_instance VI_1 {
+vrrp_instance HAPXY {
     state {% if ansible_hostname in primary %}MASTER
     {% else %}BACKUP
     {% endif %}interface eth0
@@ -30,11 +30,11 @@ vrrp_instance VI_1 {
 }
 
 {% if squid_vip is defined and ansible_fqdn in groups.loadbalancers_controlplane %}
-vrrp_instance VI_2 {
+vrrp_instance SQUID {
     state {% if ansible_hostname in primary %}BACKUP
     {% else %}MASTER
     {% endif %}interface eth0
-    virtual_router_id {% if ansible_fqdn in groups.loadbalancers_controlplane %}5{% elif ansible_fqdn in groups.loadbalancers_internet_dataplane %}6{% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}7{% endif %}2
+    virtual_router_id 52
     priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 100 on haproxy, 101 on haproxy2
     advert_int 1
     authentication {
@@ -51,7 +51,7 @@ vrrp_instance VI_2 {
 {% endif %}
 
 {% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
-vrrp_instance VI_3 {
+vrrp_instance EXGWY {
     state {% if ansible_hostname in primary %}BACKUP
     {% else %}MASTER
     {% endif %}interface eth0

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -5,7 +5,7 @@ vrrp_script chk_haproxy {
 }
 
 vrrp_script chk_squid {
-    script "/usr/bin/killall -0 squid"
+    script "ps -deaf | grep -v grep | grep squid.conf"
     interval 2 # every 2 seconds
     weight 2 # add 2 points if OK
 }

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -5,7 +5,7 @@ vrrp_script chk_haproxy {
 }
 
 vrrp_script chk_squid {
-    script "ps -deaf | grep -v grep | grep squid.conf"
+    script "pgrep squid"
     interval 2 # every 2 seconds
     weight 2 # add 2 points if OK
 }

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -14,7 +14,7 @@ vrrp_instance VI_1 {
     state {% if ansible_hostname in primary %}MASTER
     {% else %}BACKUP
     {% endif %}interface eth0
-    virtual_router_id 51
+    virtual_router_id {% if ansible_fqdn in groups.loadbalancers_controlplane %}5{% elif ansible_fqdn in groups.loadbalancers_internet_dataplane %}6{% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}7{% endif %}1
     priority {% if ansible_hostname in primary  %}101{% else %}100{% endif %} # 101 on haproxy, 100 on haproxy2
     advert_int 1
     authentication {
@@ -34,7 +34,7 @@ vrrp_instance VI_2 {
     state {% if ansible_hostname in primary %}BACKUP
     {% else %}MASTER
     {% endif %}interface eth0
-    virtual_router_id 52
+    virtual_router_id {% if ansible_fqdn in groups.loadbalancers_controlplane %}5{% elif ansible_fqdn in groups.loadbalancers_internet_dataplane %}6{% elif ansible_fqdn in groups.loadbalancers_net2_dataplane %}7{% endif %}2
     priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 100 on haproxy, 101 on haproxy2
     advert_int 1
     authentication {
@@ -55,7 +55,7 @@ vrrp_instance VI_3 {
     state {% if ansible_hostname in primary %}BACKUP
     {% else %}MASTER
     {% endif %}interface eth0
-    virtual_router_id 53
+    virtual_router_id 83
     priority {% if ansible_hostname in primary  %}100{% else %}101{% endif %} # 100 on haproxy, 101 on haproxy2
     advert_int 1
     authentication {

--- a/roles/keepalived/templates/keepalived.j2
+++ b/roles/keepalived/templates/keepalived.j2
@@ -29,6 +29,7 @@ vrrp_instance VI_1 {
     }
 }
 
+{% if squid_vip is defined and ansible_fqdn in groups.loadbalancers_controlplane %}
 vrrp_instance VI_2 {
     state {% if ansible_hostname in primary %}BACKUP
     {% else %}MASTER
@@ -47,6 +48,7 @@ vrrp_instance VI_2 {
         chk_squid
     }
 }
+{% endif %}
 
 {% if extra_gateway_vip is defined and ansible_fqdn in groups.loadbalancers_internet_dataplane %}
 vrrp_instance VI_3 {


### PR DESCRIPTION
(Tested with Feature/squidvip2 in openshift-heat - implements keystone_v3 and ocp_branding to fastforward v3.11 branch)

- Adds cor5-2 to the proxy exceptions so that multinetwork works on that OpenStack 
- Implements an extra keepalived VRRP instance to implement squid_vip
- Changes openshift ansible hosts settings to use that new squid_vip
- Altered keepalived config to ensure that each pair of loadbalancers use unique vrrp ids.
- ps and grep are used to check for squid monitoring because the kill -0 method doesn't work!