### PR TITLE
Remove openshift-ansible imports from replace_certificates playbook

### DIFF
--- a/replace_certificates.yml
+++ b/replace_certificates.yml
@@ -20,8 +20,8 @@
         replace: "{{ item.key }}: {{ item.new_path }}"
       become: yes
       with_items:
-        - { key: "certFile", old_path: "{{ namedCertificatesPath }}/fullchain1.pem", new_path: "{{ namedCertificatesPath }}/{{ certFile | basename }}"}
-        - { key: "keyFile", old_path: "{{ namedCertificatesPath }}/privkey1.pem", new_path: "{{ namedCertificatesPath }}/{{ keyFile | basename }}"}
+        - { key: "certFile", old_path: "{{ namedCertificatesPath }}/fullchain1.pem", new_path: "{{ namedCertificatesPath }}/{{ certFile | basename }}" }
+        - { key: "keyFile", old_path: "{{ namedCertificatesPath }}/privkey1.pem", new_path: "{{ namedCertificatesPath }}/{{ keyFile | basename }}" }
 
     - name: Copy named certificates
       copy:

--- a/replace_certificates.yml
+++ b/replace_certificates.yml
@@ -1,46 +1,103 @@
 ---
-- import_playbook: /usr/share/ansible/openshift-ansible/playbooks/openshift-master/redeploy-certificates.yml
+- hosts: masters
+  serial: 1
 
-- import_playbook: /usr/share/ansible/openshift-ansible/playbooks/openshift-hosted/redeploy-router-certificates.yml
+  vars:
+    masterConfigPath: "/etc/origin/master"
+    
+  tasks:
+    - name: Set certificate paths
+      set_fact:
+        namedCertificatesPath: "{{ masterConfigPath }}/named_certificates"
+        certFile: "{{ openshift_master_named_certificates[0].certfile }}"
+        keyFile: "{{ openshift_master_named_certificates[0].keyfile }}"
+        caFile: "{{ openshift_master_named_certificates[0].cafile }}"
+
+    - name: Change master-config.yaml certificate filenames
+      replace:
+        path: "{{ masterConfigPath }}/master-config.yaml"
+        regexp: "{{ item.key }}: {{ item.old_path }}$"
+        replace: "{{ item.key }}: {{ item.new_path }}"
+      become: yes
+      with_items:
+        - { key: "certFile", old_path: "{{ namedCertificatesPath }}/fullchain1.pem", new_path: "{{ namedCertificatesPath }}/{{ certFile | basename }}"}
+        - { key: "keyFile", old_path: "{{ namedCertificatesPath }}/privkey1.pem", new_path: "{{ namedCertificatesPath }}/{{ keyFile | basename }}"}
+
+    - name: Copy named certificates
+      copy:
+        src: "{{ item }}"
+        dest: "{{ namedCertificatesPath }}/{{ item | basename }}"
+        mode: '0600'
+      with_items:
+        - "{{ certFile }}"
+        - "{{ keyFile }}"
+        - "{{ caFile }}"
+      notify: restart master
+
+  handlers:
+    - name: restart master
+      command: /usr/local/bin/master-restart "{{ item }}"
+      with_items:
+      - api
+      - controllers
+      retries: 5
+      delay: 5
+      register: result
+      until: result.rc == 0
+      notify: verify API server
+      
+    - name: verify API server
+      command: >
+        curl --silent --tlsv1.2 --max-time 2
+        --cacert /etc/origin/master/ca-bundle.crt
+        https://{{ openshift_master_cluster_public_hostname }}:8443/healthz/ready
+      args:
+        warn: no
+      register: api_output
+      until: api_output.stdout == 'ok'
+      retries: 120
+      delay: 1
+      changed_when: false
 
 - hosts: masters[0]
 
   vars:
-    certificate: "{{ lookup('file', '/home/cloud-user/' + domainSuffix + '/fullchain.pem').split('\n') }}"
-    key: "{{ lookup('file', '/home/cloud-user/' + domainSuffix + '/privkey.pem').split('\n') }}"
+    certificate: "{{ lookup('file', '{{ certFile }}').split('\n') }}"
+    key: "{{ lookup('file', '{{ keyFile }}').split('\n') }}"
 
   tasks:
-    - name: Setup default router environment
-      command: /usr/local/bin/oc set env dc/router {{ item }} -n default
-      with_items:
-        - ROUTER_USE_PROXY_PROTOCOL=true
-        - ROUTER_LOG_LEVEL=debug
-
-    - name: Patch syslog pod into router deployment
-      command: /usr/local/bin/oc patch dc/router -p '{"spec":{"template":{"spec":{"containers":[{"name":"router","env":[{"name":"ROUTER_SYSLOG_ADDRESS","value":"/var/lib/rsyslog/rsyslog.sock"}],"volumeMounts":[{"mountPath":"/var/lib/rsyslog","name":"rsyslog-socket"}]},{"name":"syslog","command":["/sbin/rsyslogd","-n","-i","/tmp/rsyslog.pid","-f","/etc/rsyslog/rsyslog.conf"],"image":"registry.redhat.io/openshift3/ose-haproxy-router:v3.11","imagePullPolicy":"IfNotPresent","resources":{"requests":{"cpu":"50m","memory":"256Mi"}},"volumeMounts":[{"mountPath":"/etc/rsyslog","name":"rsyslog-config"},{"mountPath":"/var/lib/rsyslog","name":"rsyslog-socket"}]}],"volumes":[{"configMap":{"name":"rsyslog-config"},"name":"rsyslog-config"},{"emptyDir":{},"name":"rsyslog-socket"}]}}}}' -n default
+    - name: Create new router certificate
+      shell: cat {{ certFile | basename }} /etc/origin/master/ca.crt {{ keyFile | basename }} > router.pem
+      args:
+        chdir: "{{ namedCertificatesPath }}"
 
     - name: Create registry console cert
-      shell: cat fullchain.pem privkey.pem > registry.cert
+      shell: cat {{ certFile | basename }} {{ keyFile | basename }} > registry.cert
       args:
-        chdir: "/home/cloud-user/{{ domainSuffix }}"
-      delegate_to: 127.0.0.1
-      run_once: yes
+        chdir: "{{ namedCertificatesPath }}"
 
-    - name: Move registry.cert across to masters[0]
-      copy:
-        src: /home/cloud-user/{{ domainSuffix }}/registry.cert
-        dest: /home/cloud-user/registry.cert
-        owner: cloud-user
-        mode: 0644
+    - name: Pause before executing oc commands
+      pause:
+        seconds: 30
 
-    - name: Delete registry cert secret
-      command: /usr/local/bin/oc delete secret console-secret -n default
+    - name: Replace router certificate secret
+      shell: /usr/local/bin/oc create secret tls router-certs --cert=router.pem --key={{ keyFile | basename }} -n default -o json --dry-run | /usr/local/bin/oc replace -f -
+      args:
+        chdir: "{{ namedCertificatesPath }}"
+      notify: Rollout router deployment
 
-    - name: Create registry cert secret
-      command: /usr/local/bin/oc secrets new console-secret /home/cloud-user/registry.cert -n default
-
-    - name: Rollout deployment
-      command: /usr/local/bin/oc rollout latest dc/registry-console -n default
+    - name: Replace registry cert secret
+      shell: /usr/local/bin/oc create secret generic console-secret --from-file=registry.cert -n default -o json --dry-run | /usr/local/bin/oc replace -f -
+      args:
+        chdir: "{{ namedCertificatesPath }}"
+      notify: Rollout registry-console deployment
 
     - name: Patch docker-registry
       command: /usr/local/bin/oc patch route docker-registry -p '{"spec":{"tls":{"certificate":"'"{{ certificate | join("\n") }}"'","key":"'"{{ key | join("\n") }}"'"}}}' -n default
+
+  handlers:
+    - name: Rollout router deployment
+      command: /usr/local/bin/oc rollout latest dc/router -n default
+
+    - name: Rollout registry-console deployment
+      command: /usr/local/bin/oc rollout latest dc/registry-console -n default

--- a/roles/openshiftpostdeployment/tasks/main.yml
+++ b/roles/openshiftpostdeployment/tasks/main.yml
@@ -78,6 +78,14 @@
 - name: Patch nodeSelector into metrics-server deployment
   command: /usr/local/bin/oc patch deployment.apps/metrics-server -p '{"spec":{"template":{"spec":{"nodeSelector":{"infra":"'"true"'"}}}}}' -n openshift-metrics-server
 
+- name: Patch routes for updated hostnames
+  command: /usr/local/bin/oc patch route {{ item.service }} -p '{"spec":{"host":"{{ item.hostname }}.{{ domainSuffix }}"}}' -n {{ item.namespace }}
+  with_items:
+    - { service: "alertmanager-main", namespace: "openshift-monitoring", hostname: "alertmanager" }
+    - { service: "grafana", namespace: "openshift-monitoring", hostname: "grafana" }
+    - { service: "prometheus-k8s", namespace: "openshift-monitoring", hostname: "prometheus" }
+  when: getCertificates
+
 - include_tasks: routers.yml
 
 - include_tasks: squid-whitelist.yml


### PR DESCRIPTION
This is to remove unnecessary replacement of cluster-related certificates to reduce impact to cluster on automated certificate renewal.

Has been tested:

- Against 3.11 clusters deployed prior to wildcard functionality being merged (via retrofitting process)
- Against 3.11 clusters deployed with wildcard functionality (via a forced certificate renewal)