### PR TITLE
Add retries for worker test.

### DIFF
--- a/tests/worker/test-one-worker.yml
+++ b/tests/worker/test-one-worker.yml
@@ -59,9 +59,12 @@
 - name: Test the app is responding over HTTP
   uri:
     url: http://{{ oc_route_url.stdout }}
-    status_code: 200
     body: "Hello World!"
     validate_certs: no
+  register: _result
+  until: _result.status == 200
+  retries: 10
+  delay: 5
 
 - name: "Catch your breath..."
   pause: seconds=3


### PR DESCRIPTION
# Change
Running into an issue where the test tries to immediately check if the app responds however, it isn't ready yet and therefore, the test fails. These PR adds some retries to the test to check it returns a HTTP 200 response.