### PR TITLE
Addition of Slack receiver within Portworx Alertmanager config

### DIFF
--- a/roles/portworx/templates/portworx-2.1.3.j2
+++ b/roles/portworx/templates/portworx-2.1.3.j2
@@ -185,9 +185,9 @@ spec:
               value: unix:///var/lib/kubelet/plugins/com.openstorage.pxd/csi.sock
 {% if multinetwork %}
             - name: "PX_HTTP_PROXY"
-              value: "http://{{ haproxy_vip }}:3128"
+              value: "http://{{ squid_vip }}:3128"
             - name: "PX_HTTPS_PROXY"
-              value: "http://{{ haproxy_vip }}:3128"
+              value: "http://{{ squid_vip }}:3128"
 {% endif %}
 {% raw %}
           livenessProbe:
@@ -1035,8 +1035,6 @@ spec:
   endpoints:
     - port: px-api
       targetPort: 9001
-    - port: px-kvdb
-      targetPort: 9019
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
@@ -1157,7 +1155,7 @@ spec:
       annotations:
         description: Portworx cluster Quorum Unhealthy for more than 5 minutes.
         summary: Portworx Quorum Unhealthy.
-      expr: max(px_cluster_status_cluster_quorum) > 1
+      expr: min(px_cluster_status_cluster_quorum) == 0 or absent(px_cluster_status_cluster_quorum)
       for: 5m
       labels:
         issue: Portworx Quorum Unhealthy.

--- a/roles/portworx/templates/portworx-alertmanager.j2
+++ b/roles/portworx/templates/portworx-alertmanager.j2
@@ -23,3 +23,4 @@ receivers:
     text: |-
       *Cluster:* <https://ocp.{{ domainSuffix }}:8443|{{ domainSuffix }}>
 - name: 'blackhole'
+

--- a/roles/portworx/templates/portworx-alertmanager.j2
+++ b/roles/portworx/templates/portworx-alertmanager.j2
@@ -1,19 +1,25 @@
 global:
-  # The smarthost and SMTP sender used for mail notifications.
-  smtp_smarthost: "<smtpserver:port>"
-  smtp_from: "<sender-email-address>"
-  smtp_auth_username: "<sender-email-address>"
-  smtp_auth_password: "<sender-email-password>"
+
 route:
-  group_by: [Alertname]
-  # Send all notifications to me.
-  receiver: email-me
+  receiver: 'slack-UKCloud-OpenShift'
+  group_by: ['alertname']
+  routes:
+  - match_re:
+      alertname: ^PortworxVolume[a-zA-Z]*$
+    receiver: 'blackhole'
+
 receivers:
-  - name: email-me
-    email_configs:
-      - to: "<receiver-email-address>"
-        from: "<sender-email-address>"
-        smarthost: "<smtpserver:port>"
-        auth_username: "<sender-email-address>"
-        auth_identity: "<sender-email-address>"
-        auth_password: "<sender-email-password>"
+- name: 'slack-UKCloud-OpenShift'
+  slack_configs:
+  - api_url: '{{ slackWebhookUrlAcmeSh }}'
+{% if multinetwork %}
+    http_config:
+      proxy_url: http://{{ squid_vip }}:3128
+{% endif %}
+    channel: '#openshift-monitoring'
+    send_resolved: true
+    icon_emoji: ':try_not_to_cry:'
+    title_link: 'https://alertmanager-portworx-kube-system.{{ domainSuffix }}/#/alerts'
+    text: |-
+      *Cluster:* <https://ocp.{{ domainSuffix }}:8443|{{ domainSuffix }}>
+- name: 'blackhole'

--- a/roles/squid/templates/whitelist.j2
+++ b/roles/squid/templates/whitelist.j2
@@ -15,6 +15,7 @@ registry.fedoraproject.org
 .docker.com
 storage.googleapis.com
 .portworx.com
+hooks.slack.com
 {% endif %}
 
 # Squid does not support having subdomains of existing domains added


### PR DESCRIPTION
Also includes:
- change of squid vip for net2 deployments
- Removal of px-kvdb scraping since this has been deprecated
- improvement to PromQL Portworx cluster Quorum monitoring since px metrics are not scraped when Quorum is lost

Requesting review to a non-protected branch seeing as I will be approving the PR to merge the main Portworx code changes with the protected v3.11 branch