### PR TITLE
Fix postdeployment task to change journald max usage

### DIFF
--- a/roles/allserverspostdeployment/tasks/main.yml
+++ b/roles/allserverspostdeployment/tasks/main.yml
@@ -36,8 +36,8 @@
 - name: Set journal size to 3G
   replace:
     path: /etc/systemd/journald.conf
-    regexp: '^\sSystemMaxUse=.*'
-    replace: ' SystemMaxUse=3G'
+    regexp: '^\s?SystemMaxUse=.*'
+    replace: 'SystemMaxUse=3G'
   when: inventory_hostname in groups.nodes and inventory_hostname not in groups.masters
 
 - name: Restart systemd-journald service to implement journal size change


### PR DESCRIPTION
There is no longer a space at the start of the string, changing this to 0 or 1 of in Regex