### PR TITLE
Debug whitelist log

### DIFF
--- a/tools/playbooks/squid-whitelist.yaml
+++ b/tools/playbooks/squid-whitelist.yaml
@@ -27,6 +27,11 @@
     when: inventory_hostname == 'localhost' and multinetwork
     register: proxy_whitelist
 
+  - name: print whitelist to logs for debugging purposes
+    debug:
+      var: proxy_whitelist
+    when: inventory_hostname == 'localhost' and multinetwork
+
   - name: Fail play if task to retrieve whitelist fails
     fail:
       msg: "Failing to avoid blank whitelist update"

--- a/tools/playbooks/squid-whitelist.yaml
+++ b/tools/playbooks/squid-whitelist.yaml
@@ -29,7 +29,7 @@
 
   - name: print whitelist to logs for debugging purposes
     debug:
-      var: proxy_whitelist
+      var: proxy_whitelist.stdout_lines
     when: inventory_hostname == 'localhost' and multinetwork
 
   - name: Fail play if task to retrieve whitelist fails


### PR DESCRIPTION
Prints out proxy whitelist into logs for easier troubleshooting in error cases.