### PR TITLE
Verify API on localhost during replace_certificates

### DIFF
--- a/replace_certificates.yml
+++ b/replace_certificates.yml
@@ -71,6 +71,7 @@
         curl --silent --tlsv1.2 --max-time 2
         --cacert /etc/origin/master/ca-bundle.crt
         https://{{ openshift_master_cluster_public_hostname }}:8443/healthz/ready
+        --resolve {{ openshift_master_cluster_public_hostname }}:8443:127.0.0.1
       args:
         warn: no
       register: api_output


### PR DESCRIPTION
Previously the curl command to verify the API was available (post-restart) was targeting the LB which meant if a master was serving a cert signed by the old CA (as it hadn't been copied yet) the verification would fail and the remainder of the playbook wouldn't run.

This modifies the curl command to check the API service is running on localhost and to allow the remainder of the playbook to run.